### PR TITLE
Add event map viewports + analysis plumbing

### DIFF
--- a/crates/fork_core/src/event_series.rs
+++ b/crates/fork_core/src/event_series.rs
@@ -1,0 +1,622 @@
+use crate::{
+    equation_engine::{Bytecode, VM},
+    isocline::compile_scalar_expression,
+    solvers::{DiscreteMap, RK4, Tsit5},
+    traits::{DynamicalSystem, Steppable},
+};
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+
+const CROSS_EPS: f64 = 1e-12;
+const REFINE_ITERS: usize = 32;
+const TIME_EPS: f64 = 1e-12;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventSeriesMode {
+    EveryIterate,
+    CrossUp,
+    CrossDown,
+    CrossEither,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrderedSample {
+    pub time: Option<f64>,
+    pub state: Vec<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventSeriesHit {
+    pub order: usize,
+    pub sample_index: usize,
+    pub time: Option<f64>,
+    pub state: Vec<f64>,
+    pub observable_values: Vec<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventSeriesResult {
+    pub hits: Vec<EventSeriesHit>,
+}
+
+pub struct CompiledEventSeriesExpressions {
+    event: Bytecode,
+    observables: Vec<Bytecode>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum EventSeriesStepper {
+    Rk4,
+    Tsit5,
+    Discrete,
+}
+
+enum InternalStepper {
+    Rk4(RK4<f64>),
+    Tsit5(Tsit5<f64>),
+    Discrete(DiscreteMap<f64>),
+}
+
+impl EventSeriesStepper {
+    fn build(self, dim: usize) -> InternalStepper {
+        match self {
+            Self::Rk4 => InternalStepper::Rk4(RK4::new(dim)),
+            Self::Tsit5 => InternalStepper::Tsit5(Tsit5::new(dim)),
+            Self::Discrete => InternalStepper::Discrete(DiscreteMap::new(dim)),
+        }
+    }
+}
+
+impl InternalStepper {
+    fn step(
+        &mut self,
+        system: &impl DynamicalSystem<f64>,
+        t: &mut f64,
+        state: &mut [f64],
+        dt: f64,
+    ) {
+        match self {
+            Self::Rk4(stepper) => stepper.step(system, t, state, dt),
+            Self::Tsit5(stepper) => stepper.step(system, t, state, dt),
+            Self::Discrete(stepper) => stepper.step(system, t, state, dt),
+        }
+    }
+}
+
+pub fn compile_event_series_expressions(
+    event_expression: &str,
+    observable_expressions: &[String],
+    var_names: &[String],
+    param_names: &[String],
+) -> Result<CompiledEventSeriesExpressions> {
+    let event = compile_scalar_expression(event_expression, var_names, param_names)?;
+    let mut observables = Vec::with_capacity(observable_expressions.len());
+    for expression in observable_expressions {
+        observables.push(compile_scalar_expression(expression, var_names, param_names)?);
+    }
+    Ok(CompiledEventSeriesExpressions { event, observables })
+}
+
+pub fn extract_event_series_from_samples(
+    params: &[f64],
+    samples: &[OrderedSample],
+    compiled: &CompiledEventSeriesExpressions,
+    mode: EventSeriesMode,
+    level: f64,
+) -> Result<EventSeriesResult> {
+    if !level.is_finite() {
+        bail!("Event level must be finite.");
+    }
+    if samples.is_empty() {
+        return Ok(EventSeriesResult { hits: Vec::new() });
+    }
+
+    let dim = samples[0].state.len();
+    if dim == 0 {
+        bail!("Samples must have positive dimension.");
+    }
+    for (index, sample) in samples.iter().enumerate() {
+        if sample.state.len() != dim {
+            bail!(
+                "Sample {index} has dimension {} but expected {dim}.",
+                sample.state.len()
+            );
+        }
+    }
+
+    let mut hits = Vec::new();
+    let mut event_stack = Vec::with_capacity(64);
+    let mut observable_stack = Vec::with_capacity(64);
+
+    if mode == EventSeriesMode::EveryIterate {
+        for (sample_index, sample) in samples.iter().enumerate() {
+            hits.push(EventSeriesHit {
+                order: hits.len(),
+                sample_index,
+                time: sample.time,
+                state: sample.state.clone(),
+                observable_values: evaluate_observables(
+                    &compiled.observables,
+                    &sample.state,
+                    params,
+                    &mut observable_stack,
+                ),
+            });
+        }
+        return Ok(EventSeriesResult { hits });
+    }
+
+    let mut prev_value =
+        evaluate_scalar(&compiled.event, &samples[0].state, params, &mut event_stack) - level;
+    for sample_index in 1..samples.len() {
+        let next = &samples[sample_index];
+        let next_value = evaluate_scalar(&compiled.event, &next.state, params, &mut event_stack)
+            - level;
+        if matches_crossing(prev_value, next_value, mode) {
+            let prev = &samples[sample_index - 1];
+            let tau = interpolate_factor(prev_value, next_value);
+            let state = lerp_state(&prev.state, &next.state, tau);
+            hits.push(EventSeriesHit {
+                order: hits.len(),
+                sample_index,
+                time: lerp_time(prev.time, next.time, tau),
+                state: state.clone(),
+                observable_values: evaluate_observables(
+                    &compiled.observables,
+                    &state,
+                    params,
+                    &mut observable_stack,
+                ),
+            });
+        }
+        prev_value = next_value;
+    }
+
+    Ok(EventSeriesResult { hits })
+}
+
+pub fn compute_event_series_from_orbit<S>(
+    system: S,
+    stepper: EventSeriesStepper,
+    params: &[f64],
+    initial_state: &[f64],
+    initial_time: f64,
+    steps: usize,
+    dt: f64,
+    compiled: &CompiledEventSeriesExpressions,
+    mode: EventSeriesMode,
+    level: f64,
+) -> Result<EventSeriesResult>
+where
+    S: DynamicalSystem<f64>,
+{
+    if initial_state.is_empty() {
+        bail!("Initial state must have positive dimension.");
+    }
+    if steps == 0 {
+        return Ok(EventSeriesResult { hits: Vec::new() });
+    }
+    if !dt.is_finite() || dt <= 0.0 {
+        bail!("Step size dt must be positive.");
+    }
+    if !level.is_finite() {
+        bail!("Event level must be finite.");
+    }
+
+    let dim = initial_state.len();
+    let mut orbit_stepper = stepper.build(dim);
+    let mut event_stack = Vec::with_capacity(64);
+    let mut observable_stack = Vec::with_capacity(64);
+    let mut hits = Vec::new();
+    let mut t = initial_time;
+    let mut state = initial_state.to_vec();
+    let mut prev_value = evaluate_scalar(&compiled.event, &state, params, &mut event_stack) - level;
+
+    if mode == EventSeriesMode::EveryIterate {
+        hits.push(EventSeriesHit {
+            order: hits.len(),
+            sample_index: 0,
+            time: Some(t),
+            state: state.clone(),
+            observable_values: evaluate_observables(
+                &compiled.observables,
+                &state,
+                params,
+                &mut observable_stack,
+            ),
+        });
+    }
+
+    for sample_index in 1..=steps {
+        let prev_time = t;
+        let prev_state = state.clone();
+        orbit_stepper.step(&system, &mut t, &mut state, dt);
+        let next_value = evaluate_scalar(&compiled.event, &state, params, &mut event_stack) - level;
+
+        match mode {
+            EventSeriesMode::EveryIterate => {
+                hits.push(EventSeriesHit {
+                    order: hits.len(),
+                    sample_index,
+                    time: Some(t),
+                    state: state.clone(),
+                    observable_values: evaluate_observables(
+                        &compiled.observables,
+                        &state,
+                        params,
+                        &mut observable_stack,
+                    ),
+                });
+            }
+            EventSeriesMode::CrossUp
+            | EventSeriesMode::CrossDown
+            | EventSeriesMode::CrossEither => {
+                if matches_crossing(prev_value, next_value, mode) {
+                    let (hit_time, hit_state) = if matches!(stepper, EventSeriesStepper::Discrete) {
+                        (Some(t), state.clone())
+                    } else {
+                        refine_flow_crossing(
+                            &system,
+                            stepper,
+                            params,
+                            &compiled.event,
+                            level,
+                            prev_time,
+                            dt,
+                            &prev_state,
+                            prev_value,
+                            next_value,
+                        )?
+                    };
+
+                    hits.push(EventSeriesHit {
+                        order: hits.len(),
+                        sample_index,
+                        time: hit_time,
+                        state: hit_state.clone(),
+                        observable_values: evaluate_observables(
+                            &compiled.observables,
+                            &hit_state,
+                            params,
+                            &mut observable_stack,
+                        ),
+                    });
+                }
+            }
+        }
+
+        prev_value = next_value;
+    }
+
+    Ok(EventSeriesResult { hits })
+}
+
+fn evaluate_scalar(
+    bytecode: &Bytecode,
+    state: &[f64],
+    params: &[f64],
+    stack: &mut Vec<f64>,
+) -> f64 {
+    VM::execute(bytecode, state, params, stack)
+}
+
+fn evaluate_observables(
+    observables: &[Bytecode],
+    state: &[f64],
+    params: &[f64],
+    stack: &mut Vec<f64>,
+) -> Vec<f64> {
+    observables
+        .iter()
+        .map(|observable| evaluate_scalar(observable, state, params, stack))
+        .collect()
+}
+
+fn matches_crossing(prev_value: f64, next_value: f64, mode: EventSeriesMode) -> bool {
+    if !prev_value.is_finite() || !next_value.is_finite() {
+        return false;
+    }
+
+    match mode {
+        EventSeriesMode::EveryIterate => true,
+        EventSeriesMode::CrossUp => prev_value < -CROSS_EPS && next_value >= -CROSS_EPS,
+        EventSeriesMode::CrossDown => prev_value > CROSS_EPS && next_value <= CROSS_EPS,
+        EventSeriesMode::CrossEither => {
+            (prev_value < -CROSS_EPS && next_value >= -CROSS_EPS)
+                || (prev_value > CROSS_EPS && next_value <= CROSS_EPS)
+        }
+    }
+}
+
+fn interpolate_factor(prev_value: f64, next_value: f64) -> f64 {
+    let denom = next_value - prev_value;
+    if !denom.is_finite() || denom.abs() <= CROSS_EPS {
+        return 0.5;
+    }
+    ((-prev_value) / denom).clamp(0.0, 1.0)
+}
+
+fn lerp_state(prev: &[f64], next: &[f64], tau: f64) -> Vec<f64> {
+    prev.iter()
+        .zip(next.iter())
+        .map(|(left, right)| left + (right - left) * tau)
+        .collect()
+}
+
+fn lerp_time(prev: Option<f64>, next: Option<f64>, tau: f64) -> Option<f64> {
+    match (prev, next) {
+        (Some(left), Some(right)) if left.is_finite() && right.is_finite() => {
+            Some(left + (right - left) * tau)
+        }
+        _ => None,
+    }
+}
+
+fn refine_flow_crossing<S>(
+    system: &S,
+    stepper: EventSeriesStepper,
+    params: &[f64],
+    event: &Bytecode,
+    level: f64,
+    segment_start_time: f64,
+    segment_dt: f64,
+    segment_start_state: &[f64],
+    start_value: f64,
+    _end_value: f64,
+) -> Result<(Option<f64>, Vec<f64>)>
+where
+    S: DynamicalSystem<f64>,
+{
+    if segment_dt <= 0.0 {
+        bail!("Segment dt must be positive.");
+    }
+
+    let dim = segment_start_state.len();
+    let mut event_stack = Vec::with_capacity(64);
+    let mut lo_time = 0.0;
+    let mut hi_time = segment_dt;
+    let mut lo_value = start_value;
+    let mut hi_state =
+        advance_state(system, stepper, segment_start_time, segment_start_state, segment_dt);
+    let mut hit_time = segment_start_time + segment_dt;
+    let mut hit_state = hi_state.clone();
+
+    for _ in 0..REFINE_ITERS {
+        let mid_time = 0.5 * (lo_time + hi_time);
+        if (hi_time - lo_time).abs() <= TIME_EPS {
+            break;
+        }
+
+        let mid_state =
+            advance_state(system, stepper, segment_start_time, segment_start_state, mid_time);
+        if mid_state.len() != dim {
+            bail!("Refined state dimension changed during event extraction.");
+        }
+        let mid_value = evaluate_scalar(event, &mid_state, params, &mut event_stack) - level;
+
+        if mid_value.abs() <= CROSS_EPS {
+            hit_time = segment_start_time + mid_time;
+            hit_state = mid_state;
+            break;
+        }
+
+        if brackets_zero(lo_value, mid_value) {
+            hi_time = mid_time;
+            hi_state = mid_state;
+        } else {
+            lo_time = mid_time;
+            lo_value = mid_value;
+        }
+
+        hit_time = segment_start_time + hi_time;
+        hit_state = hi_state.clone();
+    }
+
+    Ok((Some(hit_time), hit_state))
+}
+
+fn brackets_zero(left: f64, right: f64) -> bool {
+    if left.abs() <= CROSS_EPS || right.abs() <= CROSS_EPS {
+        return true;
+    }
+    (left < 0.0 && right > 0.0) || (left > 0.0 && right < 0.0)
+}
+
+fn advance_state<S>(
+    system: &S,
+    stepper: EventSeriesStepper,
+    start_time: f64,
+    start_state: &[f64],
+    dt: f64,
+) -> Vec<f64>
+where
+    S: DynamicalSystem<f64>,
+{
+    if dt <= 0.0 {
+        return start_state.to_vec();
+    }
+    let mut local_t = start_time;
+    let mut state = start_state.to_vec();
+    let mut local_stepper = stepper.build(state.len());
+    local_stepper.step(system, &mut local_t, &mut state, dt);
+    state
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct LinearFlow;
+
+    impl DynamicalSystem<f64> for LinearFlow {
+        fn dimension(&self) -> usize {
+            1
+        }
+
+        fn apply(&self, _t: f64, _x: &[f64], out: &mut [f64]) {
+            out[0] = 1.0;
+        }
+    }
+
+    struct FlipMap;
+
+    impl DynamicalSystem<f64> for FlipMap {
+        fn dimension(&self) -> usize {
+            1
+        }
+
+        fn apply(&self, _t: f64, x: &[f64], out: &mut [f64]) {
+            out[0] = -x[0];
+        }
+    }
+
+    fn names() -> (Vec<String>, Vec<String>) {
+        (vec!["x".to_string()], vec!["a".to_string()])
+    }
+
+    #[test]
+    fn sampled_event_series_interpolates_parameter_observables() {
+        let (var_names, param_names) = names();
+        let compiled = compile_event_series_expressions(
+            "x",
+            &["a".to_string(), "x + a".to_string()],
+            &var_names,
+            &param_names,
+        )
+        .expect("compile");
+
+        let result = extract_event_series_from_samples(
+            &[2.0],
+            &[
+                OrderedSample {
+                    time: Some(0.0),
+                    state: vec![-1.0],
+                },
+                OrderedSample {
+                    time: Some(1.0),
+                    state: vec![1.0],
+                },
+            ],
+            &compiled,
+            EventSeriesMode::CrossUp,
+            0.0,
+        )
+        .expect("event series");
+
+        assert_eq!(result.hits.len(), 1);
+        let hit = &result.hits[0];
+        assert!((hit.time.expect("time") - 0.5).abs() < 1e-9);
+        assert!(hit.state[0].abs() < 1e-9);
+        assert_eq!(hit.observable_values.len(), 2);
+        assert!((hit.observable_values[0] - 2.0).abs() < 1e-9);
+        assert!((hit.observable_values[1] - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn sampled_event_series_preserves_hit_order() {
+        let (var_names, param_names) = names();
+        let compiled =
+            compile_event_series_expressions("x", &["x".to_string()], &var_names, &param_names)
+                .expect("compile");
+
+        let result = extract_event_series_from_samples(
+            &[0.0],
+            &[
+                OrderedSample {
+                    time: Some(0.0),
+                    state: vec![-1.0],
+                },
+                OrderedSample {
+                    time: Some(1.0),
+                    state: vec![1.0],
+                },
+                OrderedSample {
+                    time: Some(2.0),
+                    state: vec![-1.0],
+                },
+            ],
+            &compiled,
+            EventSeriesMode::CrossEither,
+            0.0,
+        )
+        .expect("event series");
+
+        assert_eq!(result.hits.len(), 2);
+        assert_eq!(result.hits[0].order, 0);
+        assert_eq!(result.hits[1].order, 1);
+        assert_eq!(result.hits[0].sample_index, 1);
+        assert_eq!(result.hits[1].sample_index, 2);
+    }
+
+    #[test]
+    fn orbit_event_series_refines_flow_crossings() {
+        let (var_names, param_names) = names();
+        let compiled =
+            compile_event_series_expressions("x", &["x".to_string()], &var_names, &param_names)
+                .expect("compile");
+
+        let result = compute_event_series_from_orbit(
+            LinearFlow,
+            EventSeriesStepper::Rk4,
+            &[0.0],
+            &[-1.0],
+            0.0,
+            10,
+            0.2,
+            &compiled,
+            EventSeriesMode::CrossUp,
+            0.0,
+        )
+        .expect("event series");
+
+        assert_eq!(result.hits.len(), 1);
+        let hit = &result.hits[0];
+        assert!((hit.time.expect("time") - 1.0).abs() < 1e-6);
+        assert!(hit.state[0].abs() < 1e-6);
+    }
+
+    #[test]
+    fn orbit_event_series_supports_map_iterates_and_crossings() {
+        let (var_names, param_names) = names();
+        let compiled =
+            compile_event_series_expressions("x", &["x".to_string()], &var_names, &param_names)
+                .expect("compile");
+
+        let every_iterate = compute_event_series_from_orbit(
+            FlipMap,
+            EventSeriesStepper::Discrete,
+            &[0.0],
+            &[1.0],
+            0.0,
+            3,
+            1.0,
+            &compiled,
+            EventSeriesMode::EveryIterate,
+            0.0,
+        )
+        .expect("every iterate");
+        assert_eq!(every_iterate.hits.len(), 4);
+        assert_eq!(every_iterate.hits[0].sample_index, 0);
+        assert_eq!(every_iterate.hits[3].sample_index, 3);
+
+        let crossings = compute_event_series_from_orbit(
+            FlipMap,
+            EventSeriesStepper::Discrete,
+            &[0.0],
+            &[1.0],
+            0.0,
+            3,
+            1.0,
+            &compiled,
+            EventSeriesMode::CrossEither,
+            0.0,
+        )
+        .expect("crossings");
+        assert_eq!(crossings.hits.len(), 3);
+        assert_eq!(crossings.hits[0].sample_index, 1);
+        assert_eq!(crossings.hits[1].sample_index, 2);
+        assert_eq!(crossings.hits[2].sample_index, 3);
+        assert_eq!(crossings.hits[0].state[0], -1.0);
+    }
+}

--- a/crates/fork_core/src/lib.rs
+++ b/crates/fork_core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod autodiff;
 pub mod continuation;
 pub mod equation_engine;
 pub mod equilibrium;
+pub mod event_series;
 pub mod isocline;
 pub mod solvers;
 /// The `fork_core` crate provides the fundamental mathematical engine for the Fork CLI.

--- a/crates/fork_wasm/src/event_series.rs
+++ b/crates/fork_wasm/src/event_series.rs
@@ -1,0 +1,105 @@
+//! Event-series extraction helpers for analysis viewports.
+
+use crate::system::{SolverType, WasmSystem};
+use fork_core::event_series::{
+    compile_event_series_expressions, compute_event_series_from_orbit,
+    extract_event_series_from_samples, EventSeriesMode, EventSeriesResult, EventSeriesStepper,
+    OrderedSample,
+};
+use serde::Deserialize;
+use serde_wasm_bindgen::{from_value, to_value};
+use wasm_bindgen::prelude::*;
+
+#[derive(Debug, Deserialize)]
+struct OrbitEventSeriesRequest {
+    var_names: Vec<String>,
+    param_names: Vec<String>,
+    initial_state: Vec<f64>,
+    start_time: f64,
+    steps: usize,
+    dt: f64,
+    mode: EventSeriesMode,
+    event_expression: String,
+    event_level: f64,
+    observable_expressions: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SampledEventSeriesRequest {
+    var_names: Vec<String>,
+    param_names: Vec<String>,
+    samples: Vec<OrderedSample>,
+    mode: EventSeriesMode,
+    event_expression: String,
+    event_level: f64,
+    observable_expressions: Vec<String>,
+}
+
+fn to_stepper(solver: &SolverType) -> EventSeriesStepper {
+    match solver {
+        SolverType::RK4(_) => EventSeriesStepper::Rk4,
+        SolverType::Tsit5(_) => EventSeriesStepper::Tsit5,
+        SolverType::Discrete(_) => EventSeriesStepper::Discrete,
+    }
+}
+
+fn serialize_result(result: EventSeriesResult) -> Result<JsValue, JsValue> {
+    to_value(&result).map_err(|err| JsValue::from_str(&format!("Serialization error: {err}")))
+}
+
+#[wasm_bindgen]
+impl WasmSystem {
+    pub fn compute_event_series_from_orbit(&self, request_val: JsValue) -> Result<JsValue, JsValue> {
+        let request: OrbitEventSeriesRequest = from_value(request_val)
+            .map_err(|err| JsValue::from_str(&format!("Invalid event series request: {err}")))?;
+        let compiled = compile_event_series_expressions(
+            &request.event_expression,
+            &request.observable_expressions,
+            &request.var_names,
+            &request.param_names,
+        )
+        .map_err(|err| JsValue::from_str(&format!("Event expression error: {err}")))?;
+
+        let result = compute_event_series_from_orbit(
+            &self.system,
+            to_stepper(&self.solver),
+            self.system.params.as_slice(),
+            &request.initial_state,
+            request.start_time,
+            request.steps,
+            request.dt,
+            &compiled,
+            request.mode,
+            request.event_level,
+        )
+        .map_err(|err| JsValue::from_str(&format!("Event series extraction failed: {err}")))?;
+
+        serialize_result(result)
+    }
+
+    pub fn compute_event_series_from_samples(
+        &self,
+        request_val: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let request: SampledEventSeriesRequest = from_value(request_val)
+            .map_err(|err| JsValue::from_str(&format!("Invalid sampled event request: {err}")))?;
+        let compiled = compile_event_series_expressions(
+            &request.event_expression,
+            &request.observable_expressions,
+            &request.var_names,
+            &request.param_names,
+        )
+        .map_err(|err| JsValue::from_str(&format!("Event expression error: {err}")))?;
+
+        let result = extract_event_series_from_samples(
+            self.system.params.as_slice(),
+            &request.samples,
+            &compiled,
+            request.mode,
+            request.event_level,
+        )
+        .map_err(|err| JsValue::from_str(&format!("Sampled event extraction failed: {err}")))?;
+
+        serialize_result(result)
+    }
+}

--- a/crates/fork_wasm/src/lib.rs
+++ b/crates/fork_wasm/src/lib.rs
@@ -3,11 +3,13 @@
 //! - `system`: core WasmSystem wrapper and utilities.
 //! - `analysis`: Lyapunov/CLV computations and runners.
 //! - `continuation`: continuation workflows and stepped runners.
+//! - `event_series`: analysis helpers for return/event maps.
 //! - `equilibrium`: equilibrium solver runner and helpers.
 
 mod analysis;
 mod continuation;
 mod equilibrium;
+mod event_series;
 mod system;
 
 pub use analysis::{WasmCovariantLyapunovRunner, WasmLyapunovRunner};

--- a/web/docs/plotly-injections.md
+++ b/web/docs/plotly-injections.md
@@ -72,6 +72,11 @@ behavior.
   (if present) into a one-time `initialView` payload for `usePlotViewport`.
   `scene.camera` is only restored for 3-axis projections; 1-axis and 2-axis
   projections restore axis ranges.
+- `web/src/analysis/AnalysisViewportPlot.tsx`: analysis return/event maps use
+  `PlotlyViewport` with declarative 2D/3D scatter layouts and one-time
+  `initialView` range restoration derived from persisted analysis
+  `axisRanges`; no direct Plotly mutation is added beyond the shared viewport
+  wrapper.
 - `web/src/ui/ViewportPanel.tsx`: map function sampling requests are limited to
   true 1D map systems (`varNames.length === 1`) and only when at least one
   visible scene is currently in `map_cobweb_1d` mode.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -157,6 +157,13 @@ function App() {
     await actions.addBifurcationDiagram(name, targetId)
   }
 
+  const createAnalysis = async (targetId?: string | null) => {
+    if (!system) return
+    const names = system.analysisViewports.map((viewport) => viewport.name)
+    const name = nextObjectName('Return_Map', names)
+    await actions.addAnalysisViewport(name, targetId)
+  }
+
   const updatePreview = (side: 'left' | 'right', nextWidth: number, workspaceWidth: number) => {
     const rawOffset =
       side === 'left' ? nextWidth : workspaceWidth - nextWidth - SPLITTER_WIDTH
@@ -285,6 +292,7 @@ function App() {
         onUpdateObjectParams={actions.updateObjectParams}
         onUpdateObjectFrozenVariables={actions.updateObjectFrozenVariables}
         onUpdateScene={actions.updateScene}
+        onUpdateAnalysisViewport={actions.updateAnalysisViewport}
         onUpdateBifurcationDiagram={actions.updateBifurcationDiagram}
         onSetLimitCycleRenderTarget={actions.setLimitCycleRenderTarget}
         onUpdateSystem={actions.updateSystem}
@@ -401,11 +409,14 @@ function App() {
                 onResizeViewport={actions.updateViewportHeight}
                 onToggleViewport={actions.toggleExpanded}
                 onCreateScene={createScene}
+                onCreateAnalysis={createAnalysis}
                 onCreateBifurcation={createBifurcation}
                 onRenameViewport={actions.renameNode}
                 onDuplicateViewport={actions.duplicateNode}
                 onDeleteViewport={actions.deleteNode}
                 onSampleMap1DFunction={actions.sampleMap1DFunction}
+                onComputeEventSeriesFromOrbit={actions.computeEventSeriesFromOrbit}
+                onComputeEventSeriesFromSamples={actions.computeEventSeriesFromSamples}
                 isoclineGeometryCache={state.isoclineGeometryCache}
               />
             </Panel>
@@ -449,6 +460,7 @@ function App() {
                 onUpdateIsoclineObject={actions.updateIsoclineObject}
                 onComputeIsocline={actions.computeIsocline}
                 onUpdateScene={actions.updateScene}
+                onUpdateAnalysisViewport={actions.updateAnalysisViewport}
                 onUpdateBifurcationDiagram={actions.updateBifurcationDiagram}
                 onSetLimitCycleRenderTarget={actions.setLimitCycleRenderTarget}
                 onUpdateSystem={actions.updateSystem}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -160,7 +160,7 @@ function App() {
   const createAnalysis = async (targetId?: string | null) => {
     if (!system) return
     const names = system.analysisViewports.map((viewport) => viewport.name)
-    const name = nextObjectName('Return_Map', names)
+    const name = nextObjectName('Event_Map', names)
     await actions.addAnalysisViewport(name, targetId)
   }
 
@@ -293,6 +293,7 @@ function App() {
         onUpdateObjectFrozenVariables={actions.updateObjectFrozenVariables}
         onUpdateScene={actions.updateScene}
         onUpdateAnalysisViewport={actions.updateAnalysisViewport}
+        onValidateAnalysisExpression={actions.validateAnalysisExpression}
         onUpdateBifurcationDiagram={actions.updateBifurcationDiagram}
         onSetLimitCycleRenderTarget={actions.setLimitCycleRenderTarget}
         onUpdateSystem={actions.updateSystem}
@@ -461,6 +462,7 @@ function App() {
                 onComputeIsocline={actions.computeIsocline}
                 onUpdateScene={actions.updateScene}
                 onUpdateAnalysisViewport={actions.updateAnalysisViewport}
+                onValidateAnalysisExpression={actions.validateAnalysisExpression}
                 onUpdateBifurcationDiagram={actions.updateBifurcationDiagram}
                 onSetLimitCycleRenderTarget={actions.setLimitCycleRenderTarget}
                 onUpdateSystem={actions.updateSystem}

--- a/web/src/analysis/AnalysisViewportPlot.tsx
+++ b/web/src/analysis/AnalysisViewportPlot.tsx
@@ -415,6 +415,34 @@ function buildLayout(
   }
 }
 
+function hashNumberSequence(values: Iterable<number>): string {
+  let hash = 0x811c9dc5
+  let count = 0
+  for (const value of values) {
+    const normalized = Number.isFinite(value)
+      ? Object.is(value, -0)
+        ? '-0'
+        : String(value)
+      : Number.isNaN(value)
+        ? 'NaN'
+        : value > 0
+          ? 'Infinity'
+          : '-Infinity'
+    for (let index = 0; index < normalized.length; index += 1) {
+      hash ^= normalized.charCodeAt(index)
+      hash = Math.imul(hash, 0x01000193)
+    }
+    hash ^= 0x2c
+    hash = Math.imul(hash, 0x01000193)
+    count += 1
+  }
+  return `${count}:${(hash >>> 0).toString(16).padStart(8, '0')}`
+}
+
+function hashMatrixRows(rows: readonly number[][]): string {
+  return hashNumberSequence(rows.flat())
+}
+
 function buildSourceSignature(system: System, sourceId: string): Record<string, unknown> {
   const node = system.nodes[sourceId]
   const nodeSignature = {
@@ -430,6 +458,7 @@ function buildSourceSignature(system: System, sourceId: string): Record<string, 
       dt: object.dt,
       tStart: object.t_start,
       tEnd: object.t_end,
+      dataHash: hashMatrixRows(object.data),
       params: object.customParameters ?? object.parameters ?? null,
       frozen: object.frozenVariables?.frozenValuesByVarName ?? null,
       snapshot: object.subsystemSnapshot?.hash ?? null,
@@ -444,6 +473,7 @@ function buildSourceSignature(system: System, sourceId: string): Record<string, 
       ncol: object.ncol,
       period: object.period,
       stateLength: object.state.length,
+      stateHash: hashNumberSequence(object.state),
       params: object.customParameters ?? object.parameters ?? null,
       frozen: object.frozenVariables?.frozenValuesByVarName ?? null,
       snapshot: object.subsystemSnapshot?.hash ?? null,
@@ -458,6 +488,7 @@ function buildSourceSignature(system: System, sourceId: string): Record<string, 
       type: branch.branchType,
       points: geometry?.points_flat.length ?? 0,
       dim: geometry?.dim ?? 0,
+      pointsHash: geometry ? hashNumberSequence(geometry.points_flat) : null,
       params: branch.params ?? null,
       snapshot: branch.subsystemSnapshot?.hash ?? null,
       node: nodeSignature,
@@ -591,8 +622,9 @@ export function AnalysisViewportPlot({
     [eventExpression, selectedNodeId, sourceIds, system, viewport]
   )
   const cacheRef = useRef(new Map<string, ComputedTraceState>())
-  const [traceState, setTraceState] = useState<ComputedTraceState>(() => {
-    return cacheRef.current.get(signature) ?? { traces: EMPTY_TRACES, message: null }
+  const [traceState, setTraceState] = useState<ComputedTraceState>({
+    traces: EMPTY_TRACES,
+    message: null,
   })
 
   useEffect(() => {

--- a/web/src/analysis/AnalysisViewportPlot.tsx
+++ b/web/src/analysis/AnalysisViewportPlot.tsx
@@ -27,7 +27,9 @@ import { PlotlyViewport, type PlotlyPointClick } from '../viewports/plotly/Plotl
 import type { PlotlyRelayoutEvent } from '../viewports/plotly/usePlotViewport'
 import type { PlotlyThemeTokens } from '../viewports/plotly/plotlyTheme'
 import {
+  normalizeAnalysisExpressionError,
   resolveAnalysisAxisLabel,
+  resolveAnalysisEventExpression,
   resolveAnalysisSourceIds,
 } from './analysisViewportUtils'
 
@@ -116,6 +118,10 @@ function resolveObservableExpressions(viewport: AnalysisViewport): string[] {
     expressions.push(axis.expression)
   }
   return expressions
+}
+
+function hasBlankObservableExpression(axis: AnalysisAxisSpec | null | undefined): boolean {
+  return axis?.kind === 'observable' && axis.expression.trim().length === 0
 }
 
 function resolveCompatibleSnapshot(
@@ -226,8 +232,8 @@ function resolveAxisValue(
     const order = hits[currentIndex]?.order
     return Number.isFinite(order) ? order : currentIndex
   }
-  const currentTime = hits[currentIndex]?.time
-  const nextTime = hits[currentIndex + 1]?.time
+  const currentTime = hits[currentIndex + axis.hitOffset]?.time
+  const nextTime = hits[currentIndex + axis.hitOffset + 1]?.time
   if (!Number.isFinite(currentTime) || !Number.isFinite(nextTime)) return null
   return (nextTime as number) - (currentTime as number)
 }
@@ -456,6 +462,7 @@ async function computeSourceTrace(
   system: System,
   viewport: AnalysisViewport,
   sourceId: string,
+  eventExpression: string,
   observableExpressions: string[],
   signal: AbortSignal,
   handlers: Pick<
@@ -486,7 +493,7 @@ async function computeSourceTrace(
           steps: Math.max(object.data.length - 1, 1),
           dt: object.dt,
           mode: viewport.event.mode,
-          eventExpression: viewport.event.expression,
+          eventExpression,
           eventLevel: viewport.event.level,
           observableExpressions,
         }, { signal })
@@ -494,7 +501,7 @@ async function computeSourceTrace(
           system: runConfig,
           samples: buildSamplesFromOrbit(systemConfig, object) ?? [],
           mode: viewport.event.mode,
-          eventExpression: viewport.event.expression,
+          eventExpression,
           eventLevel: viewport.event.level,
           observableExpressions,
         }, { signal })
@@ -512,7 +519,7 @@ async function computeSourceTrace(
         system: { ...systemConfig, params },
         samples,
         mode: viewport.event.mode,
-        eventExpression: viewport.event.expression,
+        eventExpression,
         eventLevel: viewport.event.level,
         observableExpressions,
       },
@@ -531,7 +538,7 @@ async function computeSourceTrace(
         system: { ...systemConfig, params: getBranchParams(system, branch) },
         samples,
         mode: viewport.event.mode,
-        eventExpression: viewport.event.expression,
+        eventExpression,
         eventLevel: viewport.event.level,
         observableExpressions,
       },
@@ -552,6 +559,10 @@ export function AnalysisViewportPlot({
   onComputeEventSeriesFromOrbit,
   onComputeEventSeriesFromSamples,
 }: AnalysisViewportPlotProps) {
+  const eventExpression = useMemo(
+    () => resolveAnalysisEventExpression(system.config, viewport.event),
+    [system.config, viewport.event]
+  )
   const sourceIds = useMemo(
     () => resolveAnalysisSourceIds(system, viewport, selectedNodeId),
     [selectedNodeId, system, viewport]
@@ -562,12 +573,14 @@ export function AnalysisViewportPlot({
         viewport,
         selectedNodeId: viewport.display === 'selection' ? selectedNodeId : null,
         systemType: system.config.type,
+        equations: system.config.equations,
         varNames: system.config.varNames,
         paramNames: system.config.paramNames,
         params: system.config.params,
+        eventExpression,
         sources: sourceIds.map((sourceId) => buildSourceSignature(system, sourceId)),
       }),
-    [selectedNodeId, sourceIds, system, viewport]
+    [eventExpression, selectedNodeId, sourceIds, system, viewport]
   )
   const cacheRef = useRef(new Map<string, ComputedTraceState>())
   const [traceState, setTraceState] = useState<ComputedTraceState>(() => {
@@ -591,6 +604,30 @@ export function AnalysisViewportPlot({
       return
     }
 
+    if (viewport.event.mode !== 'every_iterate' && eventExpression.trim().length === 0) {
+      const next = {
+        traces: EMPTY_TRACES,
+        message: 'Event expression is required.',
+      }
+      setTraceState(next)
+      cacheRef.current.set(signature, next)
+      return
+    }
+
+    if (
+      hasBlankObservableExpression(viewport.axes.x) ||
+      hasBlankObservableExpression(viewport.axes.y) ||
+      hasBlankObservableExpression(viewport.axes.z)
+    ) {
+      const next = {
+        traces: EMPTY_TRACES,
+        message: 'Observable axis expressions are required.',
+      }
+      setTraceState(next)
+      cacheRef.current.set(signature, next)
+      return
+    }
+
     if (sourceIds.length === 0) {
       const next = {
         traces: EMPTY_TRACES,
@@ -606,16 +643,17 @@ export function AnalysisViewportPlot({
 
     let cancelled = false
     const controller = new AbortController()
-    setTraceState({ traces: EMPTY_TRACES, message: 'Computing return map…' })
+    setTraceState({ traces: EMPTY_TRACES, message: 'Computing event map…' })
 
     void Promise.allSettled(
-      sourceIds.map((sourceId) =>
-        computeSourceTrace(
-          system,
-          viewport,
-          sourceId,
-          resolveObservableExpressions(viewport),
-          controller.signal,
+          sourceIds.map((sourceId) =>
+            computeSourceTrace(
+              system,
+              viewport,
+              sourceId,
+              eventExpression,
+              resolveObservableExpressions(viewport),
+              controller.signal,
           {
             onComputeEventSeriesFromOrbit,
             onComputeEventSeriesFromSamples,
@@ -639,7 +677,7 @@ export function AnalysisViewportPlot({
               ? null
               : rejected
                 ? rejected.reason instanceof Error
-                  ? rejected.reason.message
+                  ? normalizeAnalysisExpressionError(rejected.reason.message)
                   : String(rejected.reason)
                 : 'No event hits matched the current source, event, and axis settings.',
         }
@@ -651,7 +689,10 @@ export function AnalysisViewportPlot({
         if (error instanceof Error && error.name === 'AbortError') return
         const next = {
           traces: EMPTY_TRACES,
-          message: error instanceof Error ? error.message : String(error),
+          message:
+            error instanceof Error
+              ? normalizeAnalysisExpressionError(error.message)
+              : String(error),
         }
         setTraceState(next)
       })
@@ -663,6 +704,7 @@ export function AnalysisViewportPlot({
   }, [
     onComputeEventSeriesFromOrbit,
     onComputeEventSeriesFromSamples,
+    eventExpression,
     signature,
     sourceIds,
     system,

--- a/web/src/analysis/AnalysisViewportPlot.tsx
+++ b/web/src/analysis/AnalysisViewportPlot.tsx
@@ -416,6 +416,11 @@ function buildLayout(
 }
 
 function buildSourceSignature(system: System, sourceId: string): Record<string, unknown> {
+  const node = system.nodes[sourceId]
+  const nodeSignature = {
+    name: node?.name ?? null,
+    render: node?.render ?? null,
+  }
   const object = system.objects[sourceId]
   if (object?.type === 'orbit') {
     return {
@@ -428,6 +433,7 @@ function buildSourceSignature(system: System, sourceId: string): Record<string, 
       params: object.customParameters ?? object.parameters ?? null,
       frozen: object.frozenVariables?.frozenValuesByVarName ?? null,
       snapshot: object.subsystemSnapshot?.hash ?? null,
+      node: nodeSignature,
     }
   }
   if (object?.type === 'limit_cycle') {
@@ -441,6 +447,7 @@ function buildSourceSignature(system: System, sourceId: string): Record<string, 
       params: object.customParameters ?? object.parameters ?? null,
       frozen: object.frozenVariables?.frozenValuesByVarName ?? null,
       snapshot: object.subsystemSnapshot?.hash ?? null,
+      node: nodeSignature,
     }
   }
   const branch = system.branches[sourceId]
@@ -453,9 +460,10 @@ function buildSourceSignature(system: System, sourceId: string): Record<string, 
       dim: geometry?.dim ?? 0,
       params: branch.params ?? null,
       snapshot: branch.subsystemSnapshot?.hash ?? null,
+      node: nodeSignature,
     }
   }
-  return { id: sourceId, type: 'unknown' }
+  return { id: sourceId, type: 'unknown', node: nodeSignature }
 }
 
 async function computeSourceTrace(

--- a/web/src/analysis/AnalysisViewportPlot.tsx
+++ b/web/src/analysis/AnalysisViewportPlot.tsx
@@ -1,0 +1,698 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { Data, Layout } from 'plotly.js'
+import type {
+  AnalysisAxisSpec,
+  AnalysisViewport,
+  ContinuationObject,
+  LimitCycleObject,
+  OrbitObject,
+  SubsystemSnapshot,
+  System,
+  SystemConfig,
+} from '../system/types'
+import type {
+  ComputeEventSeriesFromOrbitRequest,
+  ComputeEventSeriesFromSamplesRequest,
+  EventSeriesHit,
+  EventSeriesOrderedSample,
+} from '../compute/ForkCoreClient'
+import { extractLimitCycleProfile, getBranchParams } from '../system/continuation'
+import { DEFAULT_RENDER } from '../system/model'
+import {
+  isSubsystemSnapshotCompatible,
+  mapStateRowsToDisplay,
+  stateVectorToDisplay,
+} from '../system/subsystemGateway'
+import { PlotlyViewport, type PlotlyPointClick } from '../viewports/plotly/PlotlyViewport'
+import type { PlotlyRelayoutEvent } from '../viewports/plotly/usePlotViewport'
+import type { PlotlyThemeTokens } from '../viewports/plotly/plotlyTheme'
+import {
+  resolveAnalysisAxisLabel,
+  resolveAnalysisSourceIds,
+} from './analysisViewportUtils'
+
+type AnalysisViewportPlotProps = {
+  system: System
+  viewport: AnalysisViewport
+  selectedNodeId: string | null
+  plotlyTheme: PlotlyThemeTokens
+  onSelectSource: (id: string) => void
+  onComputeEventSeriesFromOrbit?: (
+    request: ComputeEventSeriesFromOrbitRequest,
+    opts?: { signal?: AbortSignal }
+  ) => Promise<{ hits: EventSeriesHit[] }>
+  onComputeEventSeriesFromSamples?: (
+    request: ComputeEventSeriesFromSamplesRequest,
+    opts?: { signal?: AbortSignal }
+  ) => Promise<{ hits: EventSeriesHit[] }>
+}
+
+type ComputedTraceState = {
+  traces: Data[]
+  message: string | null
+}
+
+const EMPTY_TRACES: Data[] = []
+const LINE_STYLE_DASH = {
+  solid: 'solid',
+  dashed: 'dash',
+  dotted: 'dot',
+} as const
+
+function appendAxisRangeSnapshot(
+  snapshot: PlotlyRelayoutEvent,
+  axis: 'xaxis' | 'yaxis' | 'zaxis',
+  range: [number, number] | null | undefined,
+  is3d: boolean
+) {
+  const prefix = is3d ? `scene.${axis}` : axis
+  if (range === undefined) return
+  if (range === null) {
+    snapshot[`${prefix}.autorange`] = true
+    return
+  }
+  const start = range[0]
+  const end = range[1]
+  if (Number.isFinite(start) && Number.isFinite(end)) {
+    snapshot[`${prefix}.range`] = [start, end]
+  }
+}
+
+function buildInitialView(viewport: AnalysisViewport): PlotlyRelayoutEvent | null {
+  const snapshot: PlotlyRelayoutEvent = {}
+  const is3d = Boolean(viewport.axes.z)
+  appendAxisRangeSnapshot(snapshot, 'xaxis', viewport.axisRanges.x, is3d)
+  appendAxisRangeSnapshot(snapshot, 'yaxis', viewport.axisRanges.y, is3d)
+  if (is3d) {
+    appendAxisRangeSnapshot(snapshot, 'zaxis', viewport.axisRanges.z, true)
+  }
+  return Object.keys(snapshot).length > 0 ? snapshot : null
+}
+
+function resolveSourceParams(
+  systemConfig: SystemConfig,
+  primary?: number[] | null,
+  secondary?: number[] | null
+): number[] {
+  const isValid = (values?: number[] | null): values is number[] =>
+    Array.isArray(values) &&
+    values.length === systemConfig.params.length &&
+    values.every((value) => Number.isFinite(value))
+  if (isValid(primary)) return [...primary]
+  if (isValid(secondary)) return [...secondary]
+  return [...systemConfig.params]
+}
+
+function resolveObservableExpressions(viewport: AnalysisViewport): string[] {
+  const expressions: string[] = []
+  const seen = new Set<string>()
+  const axes = [viewport.axes.x, viewport.axes.y, viewport.axes.z].filter(
+    (axis): axis is AnalysisAxisSpec => Boolean(axis)
+  )
+  for (const axis of axes) {
+    if (axis.kind !== 'observable') continue
+    if (seen.has(axis.expression)) continue
+    seen.add(axis.expression)
+    expressions.push(axis.expression)
+  }
+  return expressions
+}
+
+function resolveCompatibleSnapshot(
+  systemConfig: SystemConfig,
+  snapshot?: SubsystemSnapshot | null
+): SubsystemSnapshot | null {
+  if (!snapshot) return null
+  return isSubsystemSnapshotCompatible(systemConfig, snapshot) ? snapshot : null
+}
+
+function resolveLineDash(style: string | undefined): 'solid' | 'dash' | 'dot' {
+  return LINE_STYLE_DASH[(style as keyof typeof LINE_STYLE_DASH) ?? 'solid'] ?? 'solid'
+}
+
+function resolveManifoldCurveGeometry(
+  geometry: ContinuationObject['data']['manifold_geometry'] | undefined
+): { dim: number; points_flat: number[] } | null {
+  if (!geometry || geometry.type !== 'Curve') return null
+  if ('Curve' in geometry && geometry.Curve) {
+    return geometry.Curve
+  }
+  if ('points_flat' in geometry && Array.isArray(geometry.points_flat)) {
+    return {
+      dim: geometry.dim,
+      points_flat: geometry.points_flat,
+    }
+  }
+  return null
+}
+
+function buildSamplesFromOrbit(
+  systemConfig: SystemConfig,
+  orbit: OrbitObject
+): EventSeriesOrderedSample[] | null {
+  if (orbit.data.length === 0) return null
+  const snapshot = resolveCompatibleSnapshot(systemConfig, orbit.subsystemSnapshot)
+  let rows = orbit.data
+  if (snapshot) {
+    rows = mapStateRowsToDisplay(snapshot, orbit.data)
+  }
+  const dimension = rows[0]?.length ? rows[0].length - 1 : 0
+  if (dimension !== systemConfig.varNames.length) {
+    return null
+  }
+  return rows.map((row) => ({
+    time: Number.isFinite(row[0]) ? row[0] : null,
+    state: row.slice(1),
+  }))
+}
+
+function buildSamplesFromLimitCycle(
+  systemConfig: SystemConfig,
+  limitCycle: LimitCycleObject
+): EventSeriesOrderedSample[] | null {
+  const snapshot = resolveCompatibleSnapshot(systemConfig, limitCycle.subsystemSnapshot)
+  const dim = snapshot?.freeVariableNames.length ?? systemConfig.varNames.length
+  const { profilePoints, period } = extractLimitCycleProfile(limitCycle.state, dim, limitCycle.ntst, limitCycle.ncol, {
+    allowPackedTail: true,
+  })
+  if (profilePoints.length === 0) return null
+  const mappedPoints = snapshot
+    ? profilePoints.map((point) => stateVectorToDisplay(snapshot, point))
+    : profilePoints.map((point) => [...point])
+  if (mappedPoints[0]?.length !== systemConfig.varNames.length) {
+    return null
+  }
+  const denominator = Math.max(mappedPoints.length - 1, 1)
+  return mappedPoints.map((state, index) => ({
+    time: Number.isFinite(period) ? (period * index) / denominator : index,
+    state,
+  }))
+}
+
+function buildSamplesFromManifold(
+  systemConfig: SystemConfig,
+  branch: ContinuationObject
+): EventSeriesOrderedSample[] | null {
+  const geometry = resolveManifoldCurveGeometry(branch.data.manifold_geometry)
+  if (!geometry || geometry.dim <= 0) return null
+  const snapshot = resolveCompatibleSnapshot(systemConfig, branch.subsystemSnapshot)
+  const samples: EventSeriesOrderedSample[] = []
+  for (let offset = 0; offset < geometry.points_flat.length; offset += geometry.dim) {
+    const point = geometry.points_flat.slice(offset, offset + geometry.dim)
+    if (point.length !== geometry.dim) continue
+    const state = snapshot ? stateVectorToDisplay(snapshot, point) : point
+    if (state.length !== systemConfig.varNames.length) return null
+    samples.push({ state })
+  }
+  return samples.length > 0 ? samples : null
+}
+
+function resolveAxisValue(
+  axis: AnalysisAxisSpec,
+  hits: EventSeriesHit[],
+  currentIndex: number,
+  observableIndexByExpression: Map<string, number>
+): number | null {
+  if (!hits[currentIndex]) return null
+  if (axis.kind === 'observable') {
+    const targetHit = hits[currentIndex + axis.hitOffset]
+    if (!targetHit) return null
+    const observableIndex = observableIndexByExpression.get(axis.expression)
+    if (observableIndex === undefined) return null
+    const value = targetHit.observable_values[observableIndex]
+    return Number.isFinite(value) ? value : null
+  }
+  if (axis.kind === 'hit_index') {
+    const order = hits[currentIndex]?.order
+    return Number.isFinite(order) ? order : currentIndex
+  }
+  const currentTime = hits[currentIndex]?.time
+  const nextTime = hits[currentIndex + 1]?.time
+  if (!Number.isFinite(currentTime) || !Number.isFinite(nextTime)) return null
+  return (nextTime as number) - (currentTime as number)
+}
+
+function buildTraceFromHits(
+  system: System,
+  viewport: AnalysisViewport,
+  sourceId: string,
+  hits: EventSeriesHit[],
+  observableIndexByExpression: Map<string, number>
+): Data | null {
+  const node = system.nodes[sourceId]
+  if (!node) return null
+  const render = { ...DEFAULT_RENDER, ...(node.render ?? {}) }
+  const x: number[] = []
+  const y: number[] = []
+  const z: number[] = []
+  const customdata: number[] = []
+  const skipHits = Math.max(0, Math.trunc(viewport.advanced.skipHits))
+  const hitStride = Math.max(1, Math.trunc(viewport.advanced.hitStride))
+  const maxHits = Math.max(1, Math.trunc(viewport.advanced.maxHits))
+  const zAxis = viewport.axes.z ?? null
+
+  for (
+    let hitIndex = skipHits, plotted = 0;
+    hitIndex < hits.length && plotted < maxHits;
+    hitIndex += hitStride
+  ) {
+    const xValue = resolveAxisValue(viewport.axes.x, hits, hitIndex, observableIndexByExpression)
+    const yValue = resolveAxisValue(viewport.axes.y, hits, hitIndex, observableIndexByExpression)
+    const zValue = zAxis
+      ? resolveAxisValue(zAxis, hits, hitIndex, observableIndexByExpression)
+      : null
+    if (!Number.isFinite(xValue) || !Number.isFinite(yValue)) continue
+    if (zAxis && !Number.isFinite(zValue)) continue
+    x.push(xValue as number)
+    y.push(yValue as number)
+    if (zAxis) {
+      z.push(zValue as number)
+    }
+    customdata.push(hits[hitIndex]?.order ?? hitIndex)
+    plotted += 1
+  }
+
+  if (x.length === 0) return null
+
+  const axisLabels = {
+    x: resolveAnalysisAxisLabel(viewport.axes.x),
+    y: resolveAnalysisAxisLabel(viewport.axes.y),
+    z: zAxis ? resolveAnalysisAxisLabel(zAxis) : null,
+  }
+  const hovertemplate = zAxis
+    ? `${axisLabels.x}: %{x}<br>${axisLabels.y}: %{y}<br>${axisLabels.z}: %{z}<br>hit: %{customdata}<extra>${node.name}</extra>`
+    : `${axisLabels.x}: %{x}<br>${axisLabels.y}: %{y}<br>hit: %{customdata}<extra>${node.name}</extra>`
+
+  if (zAxis) {
+    return {
+      type: 'scatter3d',
+      mode: viewport.advanced.connectPoints ? 'lines+markers' : 'markers',
+      uid: sourceId,
+      name: node.name,
+      x,
+      y,
+      z,
+      customdata,
+      hovertemplate,
+      marker: {
+        color: render.color,
+        size: render.pointSize,
+      },
+      line: {
+        color: render.color,
+        width: render.lineWidth,
+        dash: resolveLineDash(render.lineStyle),
+      },
+    } satisfies Data
+  }
+
+  return {
+    type: 'scattergl',
+    mode: viewport.advanced.connectPoints ? 'lines+markers' : 'markers',
+    uid: sourceId,
+    name: node.name,
+    x,
+    y,
+    customdata,
+    hovertemplate,
+    marker: {
+      color: render.color,
+      size: render.pointSize,
+    },
+    line: {
+      color: render.color,
+      width: render.lineWidth,
+      dash: resolveLineDash(render.lineStyle),
+    },
+  } satisfies Data
+}
+
+function buildLayout(
+  viewport: AnalysisViewport,
+  plotlyTheme: PlotlyThemeTokens,
+  message: string | null,
+  hasData: boolean
+): Partial<Layout> {
+  const xLabel = resolveAnalysisAxisLabel(viewport.axes.x)
+  const yLabel = resolveAnalysisAxisLabel(viewport.axes.y)
+  const zAxis = viewport.axes.z ?? null
+  const annotations: NonNullable<Layout['annotations']> = message
+    ? [
+        {
+          text: message,
+          x: 0.5,
+          y: 0.5,
+          xref: 'paper' as const,
+          yref: 'paper' as const,
+          showarrow: false,
+          font: { color: plotlyTheme.muted, size: 12 },
+        },
+      ]
+    : []
+  const base = {
+    autosize: true,
+    margin: { l: 40, r: 20, t: 20, b: 40 },
+    paper_bgcolor: plotlyTheme.background,
+    plot_bgcolor: plotlyTheme.background,
+    font: { color: plotlyTheme.text },
+    showlegend: hasData,
+    legend: {
+      font: { color: plotlyTheme.text },
+      itemclick: false,
+      itemdoubleclick: false,
+    },
+    annotations,
+  } satisfies Partial<Layout>
+
+  if (zAxis) {
+    return {
+      ...base,
+      scene: {
+        xaxis: {
+          title: { text: xLabel, font: { color: plotlyTheme.text } },
+          tickfont: { color: plotlyTheme.text },
+          zerolinecolor: 'rgba(120,120,120,0.3)',
+        },
+        yaxis: {
+          title: { text: yLabel, font: { color: plotlyTheme.text } },
+          tickfont: { color: plotlyTheme.text },
+          zerolinecolor: 'rgba(120,120,120,0.3)',
+        },
+        zaxis: {
+          title: { text: resolveAnalysisAxisLabel(zAxis), font: { color: plotlyTheme.text } },
+          tickfont: { color: plotlyTheme.text },
+          zerolinecolor: 'rgba(120,120,120,0.3)',
+        },
+        bgcolor: plotlyTheme.background,
+        aspectmode: 'cube',
+      },
+    }
+  }
+
+  return {
+    ...base,
+    dragmode: 'pan',
+    xaxis: {
+      title: { text: xLabel, font: { color: plotlyTheme.text } },
+      tickfont: { color: plotlyTheme.text },
+      zerolinecolor: 'rgba(120,120,120,0.3)',
+      gridcolor: 'rgba(120,120,120,0.15)',
+      automargin: true,
+    },
+    yaxis: {
+      title: { text: yLabel, font: { color: plotlyTheme.text } },
+      tickfont: { color: plotlyTheme.text },
+      zerolinecolor: 'rgba(120,120,120,0.3)',
+      gridcolor: 'rgba(120,120,120,0.15)',
+      automargin: true,
+    },
+  }
+}
+
+function buildSourceSignature(system: System, sourceId: string): Record<string, unknown> {
+  const object = system.objects[sourceId]
+  if (object?.type === 'orbit') {
+    return {
+      id: sourceId,
+      type: object.type,
+      rows: object.data.length,
+      dt: object.dt,
+      tStart: object.t_start,
+      tEnd: object.t_end,
+      params: object.customParameters ?? object.parameters ?? null,
+      frozen: object.frozenVariables?.frozenValuesByVarName ?? null,
+      snapshot: object.subsystemSnapshot?.hash ?? null,
+    }
+  }
+  if (object?.type === 'limit_cycle') {
+    return {
+      id: sourceId,
+      type: object.type,
+      ntst: object.ntst,
+      ncol: object.ncol,
+      period: object.period,
+      stateLength: object.state.length,
+      params: object.customParameters ?? object.parameters ?? null,
+      frozen: object.frozenVariables?.frozenValuesByVarName ?? null,
+      snapshot: object.subsystemSnapshot?.hash ?? null,
+    }
+  }
+  const branch = system.branches[sourceId]
+  if (branch?.branchType === 'eq_manifold_1d') {
+    const geometry = resolveManifoldCurveGeometry(branch.data.manifold_geometry)
+    return {
+      id: sourceId,
+      type: branch.branchType,
+      points: geometry?.points_flat.length ?? 0,
+      dim: geometry?.dim ?? 0,
+      params: branch.params ?? null,
+      snapshot: branch.subsystemSnapshot?.hash ?? null,
+    }
+  }
+  return { id: sourceId, type: 'unknown' }
+}
+
+async function computeSourceTrace(
+  system: System,
+  viewport: AnalysisViewport,
+  sourceId: string,
+  observableExpressions: string[],
+  signal: AbortSignal,
+  handlers: Pick<
+    AnalysisViewportPlotProps,
+    'onComputeEventSeriesFromOrbit' | 'onComputeEventSeriesFromSamples'
+  >
+): Promise<Data | null> {
+  const systemConfig = system.config
+  const observableIndexByExpression = new Map(
+    observableExpressions.map((expression, index) => [expression, index])
+  )
+  const object = system.objects[sourceId]
+
+  if (object?.type === 'orbit') {
+    const params = resolveSourceParams(systemConfig, object.customParameters, object.parameters)
+    const runConfig = { ...systemConfig, params }
+    const snapshot = resolveCompatibleSnapshot(systemConfig, object.subsystemSnapshot)
+    const canUseExact =
+      Boolean(handlers.onComputeEventSeriesFromOrbit) &&
+      object.data.length > 0 &&
+      (!snapshot || snapshot.freeVariableNames.length === systemConfig.varNames.length)
+
+    const result = canUseExact
+      ? await handlers.onComputeEventSeriesFromOrbit!({
+          system: runConfig,
+          initialState: object.data[0].slice(1),
+          startTime: object.t_start,
+          steps: Math.max(object.data.length - 1, 1),
+          dt: object.dt,
+          mode: viewport.event.mode,
+          eventExpression: viewport.event.expression,
+          eventLevel: viewport.event.level,
+          observableExpressions,
+        }, { signal })
+      : await handlers.onComputeEventSeriesFromSamples!({
+          system: runConfig,
+          samples: buildSamplesFromOrbit(systemConfig, object) ?? [],
+          mode: viewport.event.mode,
+          eventExpression: viewport.event.expression,
+          eventLevel: viewport.event.level,
+          observableExpressions,
+        }, { signal })
+
+    return buildTraceFromHits(system, viewport, sourceId, result.hits, observableIndexByExpression)
+  }
+
+  if (object?.type === 'limit_cycle') {
+    if (!handlers.onComputeEventSeriesFromSamples) return null
+    const params = resolveSourceParams(systemConfig, object.customParameters, object.parameters)
+    const samples = buildSamplesFromLimitCycle(systemConfig, object)
+    if (!samples || samples.length === 0) return null
+    const result = await handlers.onComputeEventSeriesFromSamples(
+      {
+        system: { ...systemConfig, params },
+        samples,
+        mode: viewport.event.mode,
+        eventExpression: viewport.event.expression,
+        eventLevel: viewport.event.level,
+        observableExpressions,
+      },
+      { signal }
+    )
+    return buildTraceFromHits(system, viewport, sourceId, result.hits, observableIndexByExpression)
+  }
+
+  const branch = system.branches[sourceId]
+  if (branch?.branchType === 'eq_manifold_1d') {
+    if (!handlers.onComputeEventSeriesFromSamples) return null
+    const samples = buildSamplesFromManifold(systemConfig, branch)
+    if (!samples || samples.length === 0) return null
+    const result = await handlers.onComputeEventSeriesFromSamples(
+      {
+        system: { ...systemConfig, params: getBranchParams(system, branch) },
+        samples,
+        mode: viewport.event.mode,
+        eventExpression: viewport.event.expression,
+        eventLevel: viewport.event.level,
+        observableExpressions,
+      },
+      { signal }
+    )
+    return buildTraceFromHits(system, viewport, sourceId, result.hits, observableIndexByExpression)
+  }
+
+  return null
+}
+
+export function AnalysisViewportPlot({
+  system,
+  viewport,
+  selectedNodeId,
+  plotlyTheme,
+  onSelectSource,
+  onComputeEventSeriesFromOrbit,
+  onComputeEventSeriesFromSamples,
+}: AnalysisViewportPlotProps) {
+  const sourceIds = useMemo(
+    () => resolveAnalysisSourceIds(system, viewport, selectedNodeId),
+    [selectedNodeId, system, viewport]
+  )
+  const signature = useMemo(
+    () =>
+      JSON.stringify({
+        viewport,
+        selectedNodeId: viewport.display === 'selection' ? selectedNodeId : null,
+        systemType: system.config.type,
+        varNames: system.config.varNames,
+        paramNames: system.config.paramNames,
+        params: system.config.params,
+        sources: sourceIds.map((sourceId) => buildSourceSignature(system, sourceId)),
+      }),
+    [selectedNodeId, sourceIds, system, viewport]
+  )
+  const cacheRef = useRef(new Map<string, ComputedTraceState>())
+  const [traceState, setTraceState] = useState<ComputedTraceState>(() => {
+    return cacheRef.current.get(signature) ?? { traces: EMPTY_TRACES, message: null }
+  })
+
+  useEffect(() => {
+    const cached = cacheRef.current.get(signature)
+    if (cached) {
+      setTraceState(cached)
+      return
+    }
+
+    if (!onComputeEventSeriesFromSamples) {
+      const next = {
+        traces: EMPTY_TRACES,
+        message: 'Analysis computation is unavailable in this build.',
+      }
+      setTraceState(next)
+      cacheRef.current.set(signature, next)
+      return
+    }
+
+    if (sourceIds.length === 0) {
+      const next = {
+        traces: EMPTY_TRACES,
+        message:
+          viewport.display === 'selection'
+            ? 'Select an orbit, limit cycle, or 1D manifold source to populate this view.'
+            : 'No compatible visible sources are available for this analysis viewport.',
+      }
+      setTraceState(next)
+      cacheRef.current.set(signature, next)
+      return
+    }
+
+    let cancelled = false
+    const controller = new AbortController()
+    setTraceState({ traces: EMPTY_TRACES, message: 'Computing return map…' })
+
+    void Promise.allSettled(
+      sourceIds.map((sourceId) =>
+        computeSourceTrace(
+          system,
+          viewport,
+          sourceId,
+          resolveObservableExpressions(viewport),
+          controller.signal,
+          {
+            onComputeEventSeriesFromOrbit,
+            onComputeEventSeriesFromSamples,
+          }
+        )
+      )
+    )
+      .then((results) => {
+        if (cancelled) return
+        const traces = results
+          .filter((result): result is PromiseFulfilledResult<Data | null> => result.status === 'fulfilled')
+          .map((result) => result.value)
+          .filter((trace): trace is Data => Boolean(trace))
+        const rejected = results.find(
+          (result): result is PromiseRejectedResult => result.status === 'rejected'
+        )
+        const next: ComputedTraceState = {
+          traces,
+          message:
+            traces.length > 0
+              ? null
+              : rejected
+                ? rejected.reason instanceof Error
+                  ? rejected.reason.message
+                  : String(rejected.reason)
+                : 'No event hits matched the current source, event, and axis settings.',
+        }
+        setTraceState(next)
+        cacheRef.current.set(signature, next)
+      })
+      .catch((error) => {
+        if (cancelled) return
+        if (error instanceof Error && error.name === 'AbortError') return
+        const next = {
+          traces: EMPTY_TRACES,
+          message: error instanceof Error ? error.message : String(error),
+        }
+        setTraceState(next)
+      })
+
+    return () => {
+      cancelled = true
+      controller.abort()
+    }
+  }, [
+    onComputeEventSeriesFromOrbit,
+    onComputeEventSeriesFromSamples,
+    signature,
+    sourceIds,
+    system,
+    viewport,
+  ])
+
+  const layout = useMemo(
+    () => buildLayout(viewport, plotlyTheme, traceState.message, traceState.traces.length > 0),
+    [plotlyTheme, traceState.message, traceState.traces.length, viewport]
+  )
+  const initialView = useMemo(() => buildInitialView(viewport), [viewport])
+  const handlePointClick = useCallback(
+    (point: PlotlyPointClick) => {
+      if (typeof point.uid === 'string') {
+        onSelectSource(point.uid)
+      }
+    },
+    [onSelectSource]
+  )
+
+  return (
+    <PlotlyViewport
+      plotId={viewport.id}
+      data={traceState.traces}
+      layout={layout}
+      viewRevision={viewport.viewRevision}
+      persistView
+      initialView={initialView}
+      testId={`plotly-viewport-${viewport.id}`}
+      onPointClick={traceState.traces.length > 0 ? handlePointClick : undefined}
+    />
+  )
+}

--- a/web/src/analysis/analysisViewportUtils.test.ts
+++ b/web/src/analysis/analysisViewportUtils.test.ts
@@ -3,6 +3,7 @@ import { addAnalysisViewport, addBranch, addObject, createSystem } from '../syst
 import type { ContinuationObject, LimitCycleObject, OrbitObject } from '../system/types'
 import {
   collectAnalysisSourceEntries,
+  resolveAnalysisEventExpression,
   resolveAnalysisAxisLabel,
   resolveAnalysisSourceIds,
 } from './analysisViewportUtils'
@@ -117,10 +118,40 @@ describe('analysisViewportUtils', () => {
       resolveAnalysisAxisLabel({
         kind: 'observable',
         expression: 'sigma',
-        hitOffset: 1,
+        hitOffset: 2,
       })
-    ).toBe('sigma@n+1')
+    ).toBe('sigma@n+2')
     expect(resolveAnalysisAxisLabel({ kind: 'hit_index' })).toBe('Hit index')
-    expect(resolveAnalysisAxisLabel({ kind: 'delta_time' })).toBe('Delta t')
+    expect(resolveAnalysisAxisLabel({ kind: 'delta_time', hitOffset: -1 })).toBe('Delta t@n-1')
+  })
+
+  it('resolves derived event expressions and every-iterate fallbacks', () => {
+    const system = createSystem({
+      name: 'Analysis_Event_Expressions',
+      config: {
+        name: 'Analysis_Event_Expressions',
+        equations: ['sigma * (y - x)', 'x * (rho - z) - y', 'x * y - beta * z'],
+        params: [10, 28, 8 / 3],
+        paramNames: ['sigma', 'rho', 'beta'],
+        varNames: ['x', 'y', 'z'],
+        solver: 'rk4',
+        type: 'flow',
+      },
+    })
+
+    expect(
+      resolveAnalysisEventExpression(system.config, {
+        mode: 'cross_up',
+        source: { kind: 'flow_derivative', variableName: 'x' },
+        level: 0,
+      })
+    ).toBe('sigma * (y - x)')
+    expect(
+      resolveAnalysisEventExpression(system.config, {
+        mode: 'every_iterate',
+        source: { kind: 'custom', expression: '' },
+        level: 0,
+      })
+    ).toBe('x')
   })
 })

--- a/web/src/analysis/analysisViewportUtils.test.ts
+++ b/web/src/analysis/analysisViewportUtils.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import { addAnalysisViewport, addBranch, addObject, createSystem } from '../system/model'
+import type { ContinuationObject, LimitCycleObject, OrbitObject } from '../system/types'
+import {
+  collectAnalysisSourceEntries,
+  resolveAnalysisAxisLabel,
+  resolveAnalysisSourceIds,
+} from './analysisViewportUtils'
+
+const BASE_SETTINGS = {
+  step_size: 0.1,
+  min_step_size: 0.01,
+  max_step_size: 0.2,
+  max_steps: 10,
+  corrector_steps: 4,
+  corrector_tolerance: 1e-6,
+  step_tolerance: 1e-6,
+} as const
+
+describe('analysisViewportUtils', () => {
+  it('collects compatible sources and resolves fallback selection rules', () => {
+    const base = createSystem({ name: 'Analysis Utils' })
+    const orbit: OrbitObject = {
+      type: 'orbit',
+      name: 'Orbit A',
+      systemName: base.name,
+      data: [
+        [0, 0, 0],
+        [0.1, 1, 1],
+      ],
+      t_start: 0,
+      t_end: 0.1,
+      dt: 0.1,
+    }
+    const withOrbit = addObject(base, orbit)
+
+    const limitCycle: LimitCycleObject = {
+      type: 'limit_cycle',
+      name: 'Cycle A',
+      systemName: base.name,
+      origin: { type: 'orbit', orbitId: withOrbit.nodeId, orbitName: 'Orbit A' },
+      ntst: 2,
+      ncol: 2,
+      period: 1,
+      state: [0, 0, 1, 0, 0, 1],
+      createdAt: new Date().toISOString(),
+    }
+    const withCycle = addObject(withOrbit.system, limitCycle)
+
+    const manifold: ContinuationObject = {
+      type: 'continuation',
+      name: 'Stable_1D',
+      systemName: base.name,
+      parameterName: 'p',
+      parentObject: withOrbit.nodeId,
+      startObject: withOrbit.nodeId,
+      branchType: 'eq_manifold_1d',
+      data: {
+        points: [],
+        bifurcations: [],
+        indices: [],
+        manifold_geometry: {
+          type: 'Curve',
+          dim: 2,
+          points_flat: [0, 0, 1, 1],
+          arclength: [0, 1],
+          direction: 'Plus',
+        },
+      },
+      settings: BASE_SETTINGS,
+      timestamp: new Date().toISOString(),
+    }
+    const withManifold = addBranch(withCycle.system, manifold, withOrbit.nodeId)
+    const incompatibleBranch: ContinuationObject = {
+      ...manifold,
+      name: 'Hopf_Curve',
+      branchType: 'hopf_curve',
+      data: { points: [], bifurcations: [], indices: [] },
+    }
+    const withBranch = addBranch(withManifold.system, incompatibleBranch, withOrbit.nodeId)
+    withBranch.system.nodes[withCycle.nodeId]!.visibility = false
+
+    const entries = collectAnalysisSourceEntries(withBranch.system)
+    expect(entries.map((entry) => ({ name: entry.name, type: entry.typeLabel, visible: entry.visible }))).toEqual([
+      { name: 'Cycle A', type: 'Limit cycle', visible: false },
+      { name: 'Orbit A', type: 'Orbit', visible: true },
+      { name: 'Stable_1D', type: '1D manifold', visible: true },
+    ])
+
+    const { system: withViewport, nodeId: viewportId } = addAnalysisViewport(withBranch.system, 'Return Map')
+    const viewport = withViewport.analysisViewports.find((entry) => entry.id === viewportId)
+    expect(viewport).toBeTruthy()
+    expect(resolveAnalysisSourceIds(withViewport, viewport!, null)).toEqual([
+      withOrbit.nodeId,
+      withManifold.nodeId,
+    ])
+
+    expect(
+      resolveAnalysisSourceIds(
+        withViewport,
+        { ...viewport!, display: 'selection' },
+        withManifold.nodeId
+      )
+    ).toEqual([withManifold.nodeId])
+
+    expect(
+      resolveAnalysisSourceIds(
+        withViewport,
+        { ...viewport!, sourceNodeIds: [withCycle.nodeId, withBranch.nodeId, withOrbit.nodeId] },
+        null
+      )
+    ).toEqual([withCycle.nodeId, withOrbit.nodeId])
+  })
+
+  it('formats implicit axis labels', () => {
+    expect(
+      resolveAnalysisAxisLabel({
+        kind: 'observable',
+        expression: 'sigma',
+        hitOffset: 1,
+      })
+    ).toBe('sigma@n+1')
+    expect(resolveAnalysisAxisLabel({ kind: 'hit_index' })).toBe('Hit index')
+    expect(resolveAnalysisAxisLabel({ kind: 'delta_time' })).toBe('Delta t')
+  })
+})

--- a/web/src/analysis/analysisViewportUtils.ts
+++ b/web/src/analysis/analysisViewportUtils.ts
@@ -1,4 +1,11 @@
-import type { AnalysisAxisSpec, AnalysisViewport, System } from '../system/types'
+import type {
+  AnalysisAxisSpec,
+  AnalysisEventSpec,
+  AnalysisViewport,
+  IsoclineSource,
+  System,
+  SystemConfig,
+} from '../system/types'
 
 export type AnalysisSourceEntry = {
   id: string
@@ -7,9 +14,36 @@ export type AnalysisSourceEntry = {
   visible: boolean
 }
 
-function formatObservableOffset(hitOffset: -1 | 0 | 1): string {
+export function formatAnalysisHitOffset(hitOffset: number): string {
   if (hitOffset === 0) return 'n'
   return hitOffset > 0 ? `n+${hitOffset}` : `n${hitOffset}`
+}
+
+export function resolveAnalysisSourceExpression(
+  systemConfig: SystemConfig,
+  source: IsoclineSource
+): string {
+  if (source.kind === 'custom') return source.expression
+  const index = systemConfig.varNames.indexOf(source.variableName)
+  if (index < 0 || index >= systemConfig.equations.length) return ''
+  if (source.kind === 'flow_derivative') {
+    return systemConfig.equations[index] ?? ''
+  }
+  return `(${systemConfig.equations[index] ?? ''}) - (${source.variableName})`
+}
+
+export function resolveAnalysisEventExpression(
+  systemConfig: SystemConfig,
+  event: AnalysisEventSpec
+): string {
+  if (event.mode === 'every_iterate') {
+    return systemConfig.varNames[0] ?? systemConfig.paramNames[0] ?? '0'
+  }
+  return resolveAnalysisSourceExpression(systemConfig, event.source)
+}
+
+export function normalizeAnalysisExpressionError(message: string): string {
+  return message.replace(/^Event expression error:\s*/i, '').trim()
 }
 
 function formatSourceTypeLabel(system: System, nodeId: string): string {
@@ -82,8 +116,8 @@ export function resolveAnalysisAxisLabel(axis: AnalysisAxisSpec): string {
   const trimmedLabel = axis.label?.trim()
   if (trimmedLabel) return trimmedLabel
   if (axis.kind === 'observable') {
-    return `${axis.expression}@${formatObservableOffset(axis.hitOffset)}`
+    return `${axis.expression}@${formatAnalysisHitOffset(axis.hitOffset)}`
   }
   if (axis.kind === 'hit_index') return 'Hit index'
-  return 'Delta t'
+  return `Delta t@${formatAnalysisHitOffset(axis.hitOffset)}`
 }

--- a/web/src/analysis/analysisViewportUtils.ts
+++ b/web/src/analysis/analysisViewportUtils.ts
@@ -1,0 +1,89 @@
+import type { AnalysisAxisSpec, AnalysisViewport, System } from '../system/types'
+
+export type AnalysisSourceEntry = {
+  id: string
+  name: string
+  typeLabel: string
+  visible: boolean
+}
+
+function formatObservableOffset(hitOffset: -1 | 0 | 1): string {
+  if (hitOffset === 0) return 'n'
+  return hitOffset > 0 ? `n+${hitOffset}` : `n${hitOffset}`
+}
+
+function formatSourceTypeLabel(system: System, nodeId: string): string {
+  const object = system.objects[nodeId]
+  if (object?.type === 'orbit') return 'Orbit'
+  if (object?.type === 'limit_cycle') return 'Limit cycle'
+  const branch = system.branches[nodeId]
+  if (branch?.branchType === 'eq_manifold_1d') return '1D manifold'
+  return 'Analysis source'
+}
+
+export function isAnalysisSourceNode(system: System, nodeId: string): boolean {
+  const node = system.nodes[nodeId]
+  if (!node) return false
+  if (node.kind === 'object') {
+    const object = system.objects[nodeId]
+    return object?.type === 'orbit' || object?.type === 'limit_cycle'
+  }
+  if (node.kind === 'branch') {
+    return system.branches[nodeId]?.branchType === 'eq_manifold_1d'
+  }
+  return false
+}
+
+export function collectAnalysisSourceEntries(system: System): AnalysisSourceEntry[] {
+  const entries: AnalysisSourceEntry[] = []
+  const stack = [...system.rootIds]
+  const visited = new Set<string>()
+  while (stack.length > 0) {
+    const nodeId = stack.pop()
+    if (!nodeId || visited.has(nodeId)) continue
+    visited.add(nodeId)
+    const node = system.nodes[nodeId]
+    if (!node) continue
+    if (node.children.length > 0) {
+      stack.push(...node.children)
+    }
+    if (!isAnalysisSourceNode(system, nodeId)) continue
+    entries.push({
+      id: nodeId,
+      name: node.name,
+      typeLabel: formatSourceTypeLabel(system, nodeId),
+      visible: node.visibility,
+    })
+  }
+  return entries.sort((left, right) => left.name.localeCompare(right.name))
+}
+
+export function resolveAnalysisSourceIds(
+  system: System,
+  viewport: AnalysisViewport,
+  selectedNodeId: string | null
+): string[] {
+  if (viewport.sourceNodeIds.length > 0) {
+    return viewport.sourceNodeIds.filter((nodeId) => isAnalysisSourceNode(system, nodeId))
+  }
+  if (
+    viewport.display === 'selection' &&
+    selectedNodeId &&
+    isAnalysisSourceNode(system, selectedNodeId)
+  ) {
+    return [selectedNodeId]
+  }
+  return collectAnalysisSourceEntries(system)
+    .filter((entry) => entry.visible)
+    .map((entry) => entry.id)
+}
+
+export function resolveAnalysisAxisLabel(axis: AnalysisAxisSpec): string {
+  const trimmedLabel = axis.label?.trim()
+  if (trimmedLabel) return trimmedLabel
+  if (axis.kind === 'observable') {
+    return `${axis.expression}@${formatObservableOffset(axis.hitOffset)}`
+  }
+  if (axis.kind === 'hit_index') return 'Hit index'
+  return 'Delta t'
+}

--- a/web/src/compute/ForkCoreClient.ts
+++ b/web/src/compute/ForkCoreClient.ts
@@ -5,6 +5,7 @@ import type {
   Manifold2DProfile,
   ManifoldStability,
   EquilibriumSolution,
+  EventSeriesMode,
   SystemConfig,
 } from '../system/types'
 
@@ -30,6 +31,44 @@ export type SimulateOrbitResult = {
   t_start: number
   t_end: number
   dt: number
+}
+
+export type EventSeriesOrderedSample = {
+  time?: number | null
+  state: number[]
+}
+
+export type EventSeriesHit = {
+  order: number
+  sample_index: number
+  time?: number | null
+  state: number[]
+  observable_values: number[]
+}
+
+export type EventSeriesResult = {
+  hits: EventSeriesHit[]
+}
+
+export type ComputeEventSeriesFromOrbitRequest = {
+  system: SystemConfig
+  initialState: number[]
+  startTime: number
+  steps: number
+  dt: number
+  mode: EventSeriesMode
+  eventExpression: string
+  eventLevel: number
+  observableExpressions: string[]
+}
+
+export type ComputeEventSeriesFromSamplesRequest = {
+  system: SystemConfig
+  samples: EventSeriesOrderedSample[]
+  mode: EventSeriesMode
+  eventExpression: string
+  eventLevel: number
+  observableExpressions: string[]
 }
 
 export type SampleMap1DFunctionRequest = {
@@ -463,6 +502,14 @@ export interface ForkCoreClient {
     request: SampleMap1DFunctionRequest,
     opts?: { signal?: AbortSignal }
   ): Promise<SampleMap1DFunctionResult>
+  computeEventSeriesFromOrbit(
+    request: ComputeEventSeriesFromOrbitRequest,
+    opts?: { signal?: AbortSignal }
+  ): Promise<EventSeriesResult>
+  computeEventSeriesFromSamples(
+    request: ComputeEventSeriesFromSamplesRequest,
+    opts?: { signal?: AbortSignal }
+  ): Promise<EventSeriesResult>
   computeIsocline(
     request: ComputeIsoclineRequest,
     opts?: { signal?: AbortSignal }

--- a/web/src/compute/mockClient.ts
+++ b/web/src/compute/mockClient.ts
@@ -1,7 +1,12 @@
 import type {
+  ComputeEventSeriesFromOrbitRequest,
+  ComputeEventSeriesFromSamplesRequest,
   ComputeIsoclineRequest,
   ComputeIsoclineResult,
   Codim1CurveBranch,
+  EventSeriesHit,
+  EventSeriesOrderedSample,
+  EventSeriesResult,
   ContinuationProgress,
   ContinuationExtensionRequest,
   ContinuationExtensionResult,
@@ -48,6 +53,94 @@ import { isDeterministicMode } from '../utils/determinism'
 
 function delay(ms: number) {
   return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+function compileMockExpression(expression: string, argNames: string[]): (...values: number[]) => number {
+  return new Function(...argNames, `return (${expression});`) as (...values: number[]) => number
+}
+
+function evaluateMockExpression(
+  expression: string,
+  varNames: string[],
+  paramNames: string[],
+  state: number[],
+  params: number[]
+): number {
+  const evaluator = compileMockExpression(expression, [...varNames, ...paramNames])
+  const values = [
+    ...varNames.map((_, index) => state[index] ?? 0),
+    ...paramNames.map((_, index) => params[index] ?? 0),
+  ]
+  const result = evaluator(...values)
+  return typeof result === 'number' && Number.isFinite(result) ? result : Number.NaN
+}
+
+function interpolateMockState(a: number[], b: number[], tau: number): number[] {
+  return a.map((value, index) => value + ((b[index] ?? value) - value) * tau)
+}
+
+function matchesMockCrossing(mode: string, prevValue: number, nextValue: number): boolean {
+  if (mode === 'cross_up') return prevValue < 0 && nextValue >= 0
+  if (mode === 'cross_down') return prevValue > 0 && nextValue <= 0
+  if (mode === 'cross_either') {
+    return (prevValue < 0 && nextValue >= 0) || (prevValue > 0 && nextValue <= 0)
+  }
+  return false
+}
+
+function buildMockEventSeries(request: ComputeEventSeriesFromSamplesRequest): EventSeriesResult {
+  const { system, samples, eventExpression, eventLevel, observableExpressions, mode } = request
+  const observables = (state: number[]) =>
+    observableExpressions.map((expression) =>
+      evaluateMockExpression(expression, system.varNames, system.paramNames, state, system.params)
+    )
+  if (mode === 'every_iterate') {
+    return {
+      hits: samples.map((sample, index) => ({
+        order: index,
+        sample_index: index,
+        time: sample.time ?? null,
+        state: [...sample.state],
+        observable_values: observables(sample.state),
+      })),
+    }
+  }
+  const hits: EventSeriesHit[] = []
+  for (let index = 1; index < samples.length; index += 1) {
+    const prev = samples[index - 1]
+    const next = samples[index]
+    const prevValue =
+      evaluateMockExpression(
+        eventExpression,
+        system.varNames,
+        system.paramNames,
+        prev.state,
+        system.params
+      ) - eventLevel
+    const nextValue =
+      evaluateMockExpression(
+        eventExpression,
+        system.varNames,
+        system.paramNames,
+        next.state,
+        system.params
+      ) - eventLevel
+    if (!matchesMockCrossing(mode, prevValue, nextValue)) continue
+    const tau = nextValue === prevValue ? 1 : Math.min(Math.max(-prevValue / (nextValue - prevValue), 0), 1)
+    const state = interpolateMockState(prev.state, next.state, tau)
+    const time =
+      prev.time == null || next.time == null
+        ? next.time ?? null
+        : prev.time + ((next.time - prev.time) * tau)
+    hits.push({
+      order: hits.length,
+      sample_index: index,
+      time,
+      state,
+      observable_values: observables(state),
+    })
+  }
+  return { hits }
 }
 
 export class MockForkCoreClient implements ForkCoreClient {
@@ -137,6 +230,63 @@ export class MockForkCoreClient implements ForkCoreClient {
           y.push(t)
         }
         return { x, y }
+      },
+      opts
+    )
+    return await job.promise
+  }
+
+  async computeEventSeriesFromOrbit(
+    request: ComputeEventSeriesFromOrbitRequest,
+    opts?: { signal?: AbortSignal }
+  ): Promise<EventSeriesResult> {
+    const job = this.queue.enqueue(
+      'computeEventSeriesFromOrbit',
+      async (signal) => {
+        if (this.delayMs > 0) await delay(this.delayMs)
+        if (signal.aborted) {
+          const error = new Error('cancelled')
+          error.name = 'AbortError'
+          throw error
+        }
+
+        const samples: EventSeriesOrderedSample[] = []
+        for (let index = 0; index <= request.steps; index += 1) {
+          const time = request.startTime + index * request.dt
+          const state = request.initialState.map((value, axis) => {
+            const phase = time + axis * 0.7
+            return value + Math.sin(phase)
+          })
+          samples.push({ time, state })
+        }
+        return buildMockEventSeries({
+          system: request.system,
+          samples,
+          mode: request.mode,
+          eventExpression: request.eventExpression,
+          eventLevel: request.eventLevel,
+          observableExpressions: request.observableExpressions,
+        })
+      },
+      opts
+    )
+    return await job.promise
+  }
+
+  async computeEventSeriesFromSamples(
+    request: ComputeEventSeriesFromSamplesRequest,
+    opts?: { signal?: AbortSignal }
+  ): Promise<EventSeriesResult> {
+    const job = this.queue.enqueue(
+      'computeEventSeriesFromSamples',
+      async (signal) => {
+        if (this.delayMs > 0) await delay(this.delayMs)
+        if (signal.aborted) {
+          const error = new Error('cancelled')
+          error.name = 'AbortError'
+          throw error
+        }
+        return buildMockEventSeries(request)
       },
       opts
     )

--- a/web/src/compute/wasmClient.ts
+++ b/web/src/compute/wasmClient.ts
@@ -1,7 +1,10 @@
 import type {
+  ComputeEventSeriesFromOrbitRequest,
+  ComputeEventSeriesFromSamplesRequest,
   ComputeIsoclineRequest,
   ComputeIsoclineResult,
   Codim1CurveBranch,
+  EventSeriesResult,
   ContinuationProgress,
   ContinuationExtensionRequest,
   ContinuationExtensionResult,
@@ -48,6 +51,12 @@ import { makeStableId } from '../utils/determinism'
 type WorkerRequest =
   | { id: string; kind: 'simulateOrbit'; payload: SimulateOrbitRequest }
   | { id: string; kind: 'sampleMap1DFunction'; payload: SampleMap1DFunctionRequest }
+  | { id: string; kind: 'computeEventSeriesFromOrbit'; payload: ComputeEventSeriesFromOrbitRequest }
+  | {
+      id: string
+      kind: 'computeEventSeriesFromSamples'
+      payload: ComputeEventSeriesFromSamplesRequest
+    }
   | { id: string; kind: 'computeIsocline'; payload: ComputeIsoclineRequest }
   | { id: string; kind: 'computeLyapunovExponents'; payload: LyapunovExponentsRequest }
   | { id: string; kind: 'computeCovariantLyapunovVectors'; payload: CovariantLyapunovRequest }
@@ -117,6 +126,7 @@ type WorkerResponse =
       result:
         | SimulateOrbitResult
         | SampleMap1DFunctionResult
+        | EventSeriesResult
         | ComputeIsoclineResult
         | number[]
         | CovariantLyapunovResponse
@@ -146,6 +156,7 @@ export class WasmForkCoreClient implements ForkCoreClient {
         value:
           | SimulateOrbitResult
           | SampleMap1DFunctionResult
+          | EventSeriesResult
           | ComputeIsoclineResult
           | number[]
           | CovariantLyapunovResponse
@@ -212,6 +223,30 @@ export class WasmForkCoreClient implements ForkCoreClient {
     const job = this.queue.enqueue(
       'sampleMap1DFunction',
       (signal) => this.runWorker('sampleMap1DFunction', request, signal),
+      opts
+    )
+    return await job.promise
+  }
+
+  async computeEventSeriesFromOrbit(
+    request: ComputeEventSeriesFromOrbitRequest,
+    opts?: { signal?: AbortSignal }
+  ): Promise<EventSeriesResult> {
+    const job = this.queue.enqueue(
+      'computeEventSeriesFromOrbit',
+      (signal) => this.runWorker('computeEventSeriesFromOrbit', request, signal),
+      opts
+    )
+    return await job.promise
+  }
+
+  async computeEventSeriesFromSamples(
+    request: ComputeEventSeriesFromSamplesRequest,
+    opts?: { signal?: AbortSignal }
+  ): Promise<EventSeriesResult> {
+    const job = this.queue.enqueue(
+      'computeEventSeriesFromSamples',
+      (signal) => this.runWorker('computeEventSeriesFromSamples', request, signal),
       opts
     )
     return await job.promise
@@ -545,6 +580,16 @@ export class WasmForkCoreClient implements ForkCoreClient {
     signal: AbortSignal
   ): Promise<SampleMap1DFunctionResult>
   private runWorker(
+    kind: 'computeEventSeriesFromOrbit',
+    payload: ComputeEventSeriesFromOrbitRequest,
+    signal: AbortSignal
+  ): Promise<EventSeriesResult>
+  private runWorker(
+    kind: 'computeEventSeriesFromSamples',
+    payload: ComputeEventSeriesFromSamplesRequest,
+    signal: AbortSignal
+  ): Promise<EventSeriesResult>
+  private runWorker(
     kind: 'computeIsocline',
     payload: ComputeIsoclineRequest,
     signal: AbortSignal
@@ -674,6 +719,8 @@ export class WasmForkCoreClient implements ForkCoreClient {
     kind:
       | 'simulateOrbit'
       | 'sampleMap1DFunction'
+      | 'computeEventSeriesFromOrbit'
+      | 'computeEventSeriesFromSamples'
       | 'computeIsocline'
       | 'computeLyapunovExponents'
       | 'computeCovariantLyapunovVectors'
@@ -699,6 +746,8 @@ export class WasmForkCoreClient implements ForkCoreClient {
     payload:
       | SimulateOrbitRequest
       | SampleMap1DFunctionRequest
+      | ComputeEventSeriesFromOrbitRequest
+      | ComputeEventSeriesFromSamplesRequest
       | ComputeIsoclineRequest
       | LyapunovExponentsRequest
       | CovariantLyapunovRequest
@@ -726,6 +775,7 @@ export class WasmForkCoreClient implements ForkCoreClient {
   ): Promise<
     | SimulateOrbitResult
     | SampleMap1DFunctionResult
+    | EventSeriesResult
     | ComputeIsoclineResult
     | number[]
     | CovariantLyapunovResponse
@@ -748,8 +798,12 @@ export class WasmForkCoreClient implements ForkCoreClient {
         ? { id, kind, payload: payload as SimulateOrbitRequest }
         : kind === 'sampleMap1DFunction'
           ? { id, kind, payload: payload as SampleMap1DFunctionRequest }
-          : kind === 'computeIsocline'
-            ? { id, kind, payload: payload as ComputeIsoclineRequest }
+          : kind === 'computeEventSeriesFromOrbit'
+            ? { id, kind, payload: payload as ComputeEventSeriesFromOrbitRequest }
+            : kind === 'computeEventSeriesFromSamples'
+              ? { id, kind, payload: payload as ComputeEventSeriesFromSamplesRequest }
+              : kind === 'computeIsocline'
+                ? { id, kind, payload: payload as ComputeIsoclineRequest }
         : kind === 'computeLyapunovExponents'
           ? { id, kind, payload: payload as LyapunovExponentsRequest }
           : kind === 'computeCovariantLyapunovVectors'
@@ -803,6 +857,7 @@ export class WasmForkCoreClient implements ForkCoreClient {
     const promise = new Promise<
       | SimulateOrbitResult
       | SampleMap1DFunctionResult
+      | EventSeriesResult
       | ComputeIsoclineResult
       | number[]
       | CovariantLyapunovResponse

--- a/web/src/compute/worker/forkCoreWorker.ts
+++ b/web/src/compute/worker/forkCoreWorker.ts
@@ -1,24 +1,31 @@
 /// <reference lib="webworker" />
 
 import type {
+  ComputeEventSeriesFromOrbitRequest,
+  ComputeEventSeriesFromSamplesRequest,
   ComputeIsoclineRequest,
   ComputeIsoclineResult,
   Codim1CurveBranch,
   ContinuationProgress,
   ContinuationExtensionRequest,
   ContinuationExtensionResult,
+  CovariantLyapunovRequest,
+  CovariantLyapunovResponse,
+  EquilibriumContinuationRequest,
+  EquilibriumContinuationResult,
   EquilibriumManifold1DRequest,
   EquilibriumManifold1DResult,
   EquilibriumManifold2DRequest,
   EquilibriumManifold2DResult,
-  EquilibriumContinuationRequest,
-  EquilibriumContinuationResult,
+  EventSeriesResult,
+  FoldCurveContinuationRequest,
   HomoclinicContinuationResult,
   HomoclinicFromHomoclinicRequest,
   HomoclinicFromHomotopySaddleRequest,
   HomoclinicFromLargeCycleRequest,
   HomotopySaddleContinuationResult,
   HomotopySaddleFromEquilibriumRequest,
+  HopfCurveContinuationRequest,
   IsochroneCurveContinuationRequest,
   LimitCycleContinuationFromHopfRequest,
   LimitCycleContinuationFromOrbitRequest,
@@ -28,18 +35,14 @@ import type {
   LimitCycleFloquetModesResult,
   LimitCycleManifold2DRequest,
   LimitCycleManifold2DResult,
-  MapCycleContinuationFromPDRequest,
-  CovariantLyapunovRequest,
-  CovariantLyapunovResponse,
-  FoldCurveContinuationRequest,
-  HopfCurveContinuationRequest,
   LyapunovExponentsRequest,
+  MapCycleContinuationFromPDRequest,
   SampleMap1DFunctionRequest,
   SampleMap1DFunctionResult,
-  SolveEquilibriumRequest,
-  SolveEquilibriumResult,
   SimulateOrbitRequest,
   SimulateOrbitResult,
+  SolveEquilibriumRequest,
+  SolveEquilibriumResult,
   ValidateSystemRequest,
   ValidateSystemResult,
 } from '../ForkCoreClient'
@@ -48,6 +51,12 @@ import { discardHomoclinicInitialApproximationPoint } from '../../system/continu
 type WorkerRequest =
   | { id: string; kind: 'simulateOrbit'; payload: SimulateOrbitRequest }
   | { id: string; kind: 'sampleMap1DFunction'; payload: SampleMap1DFunctionRequest }
+  | { id: string; kind: 'computeEventSeriesFromOrbit'; payload: ComputeEventSeriesFromOrbitRequest }
+  | {
+      id: string
+      kind: 'computeEventSeriesFromSamples'
+      payload: ComputeEventSeriesFromSamplesRequest
+    }
   | { id: string; kind: 'computeIsocline'; payload: ComputeIsoclineRequest }
   | { id: string; kind: 'computeLyapunovExponents'; payload: LyapunovExponentsRequest }
   | { id: string; kind: 'computeCovariantLyapunovVectors'; payload: CovariantLyapunovRequest }
@@ -117,6 +126,7 @@ type WorkerResponse =
       result:
         | SimulateOrbitResult
         | SampleMap1DFunctionResult
+        | EventSeriesResult
         | ComputeIsoclineResult
         | number[]
         | CovariantLyapunovResponse
@@ -150,6 +160,10 @@ type WasmModule = {
     set_t: (t: number) => void
     get_t: () => number
     step: (dt: number) => void
+    compute_event_series_from_orbit?: (request: Record<string, unknown>) => EventSeriesResult
+    computeEventSeriesFromOrbit?: (request: Record<string, unknown>) => EventSeriesResult
+    compute_event_series_from_samples?: (request: Record<string, unknown>) => EventSeriesResult
+    computeEventSeriesFromSamples?: (request: Record<string, unknown>) => EventSeriesResult
     compute_isocline?: (
       expression: string,
       level: number,
@@ -589,6 +603,84 @@ async function runSampleMap1DFunction(
   }
 
   return { x: xValues, y: yValues }
+}
+
+async function runComputeEventSeriesFromOrbit(
+  request: ComputeEventSeriesFromOrbitRequest,
+  signal: AbortSignal
+): Promise<EventSeriesResult> {
+  abortIfNeeded(signal)
+  const wasm = await loadWasm()
+  const system = new wasm.WasmSystem(
+    request.system.equations,
+    new Float64Array(request.system.params),
+    request.system.paramNames,
+    request.system.varNames,
+    request.system.solver,
+    request.system.type
+  )
+  abortIfNeeded(signal)
+
+  const computeEventSeries =
+    system.compute_event_series_from_orbit ?? system.computeEventSeriesFromOrbit
+  if (typeof computeEventSeries !== 'function') {
+    throw new Error(
+      'Event-series computation is unavailable in this WASM build. Rebuild fork_wasm pkg-web.'
+    )
+  }
+  const result = computeEventSeries.call(system, {
+    var_names: request.system.varNames,
+    param_names: request.system.paramNames,
+    initial_state: request.initialState,
+    start_time: request.startTime,
+    steps: request.steps,
+    dt: request.dt,
+    mode: request.mode,
+    event_expression: request.eventExpression,
+    event_level: request.eventLevel,
+    observable_expressions: request.observableExpressions,
+  })
+  abortIfNeeded(signal)
+  return result
+}
+
+async function runComputeEventSeriesFromSamples(
+  request: ComputeEventSeriesFromSamplesRequest,
+  signal: AbortSignal
+): Promise<EventSeriesResult> {
+  abortIfNeeded(signal)
+  const wasm = await loadWasm()
+  const system = new wasm.WasmSystem(
+    request.system.equations,
+    new Float64Array(request.system.params),
+    request.system.paramNames,
+    request.system.varNames,
+    request.system.solver,
+    request.system.type
+  )
+  abortIfNeeded(signal)
+
+  const computeEventSeries =
+    system.compute_event_series_from_samples ?? system.computeEventSeriesFromSamples
+  if (typeof computeEventSeries !== 'function') {
+    throw new Error(
+      'Event-series computation is unavailable in this WASM build. Rebuild fork_wasm pkg-web.'
+    )
+  }
+  const result = computeEventSeries.call(system, {
+    var_names: request.system.varNames,
+    param_names: request.system.paramNames,
+    samples: request.samples.map((sample) => ({
+      state: sample.state,
+      time: sample.time ?? null,
+    })),
+    mode: request.mode,
+    event_expression: request.eventExpression,
+    event_level: request.eventLevel,
+    observable_expressions: request.observableExpressions,
+  })
+  abortIfNeeded(signal)
+  return result
 }
 
 async function runComputeIsocline(
@@ -1730,6 +1822,20 @@ ctx.onmessage = async (event: MessageEvent<WorkerRequest>) => {
 
     if (message.kind === 'sampleMap1DFunction') {
       const result = await runSampleMap1DFunction(message.payload, controller.signal)
+      const response: WorkerResponse = { id: message.id, ok: true, result }
+      ctx.postMessage(response)
+      return
+    }
+
+    if (message.kind === 'computeEventSeriesFromOrbit') {
+      const result = await runComputeEventSeriesFromOrbit(message.payload, controller.signal)
+      const response: WorkerResponse = { id: message.id, ok: true, result }
+      ctx.postMessage(response)
+      return
+    }
+
+    if (message.kind === 'computeEventSeriesFromSamples') {
+      const result = await runComputeEventSeriesFromSamples(message.payload, controller.signal)
       const response: WorkerResponse = { id: message.id, ok: true, result }
       ctx.postMessage(response)
       return

--- a/web/src/state/appState.tsx
+++ b/web/src/state/appState.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
 import type {
+  ComputeEventSeriesFromOrbitRequest,
+  ComputeEventSeriesFromSamplesRequest,
   ComputeIsoclineRequest as CoreComputeIsoclineRequest,
   ComputeIsoclineResult,
   ContinuationProgress,
   CovariantLyapunovRequest as CoreCovariantLyapunovRequest,
   CovariantLyapunovResponse,
+  EventSeriesResult,
   ForkCoreClient,
   LimitCycleFloquetModesRequest as CoreLimitCycleFloquetModesRequest,
   LyapunovExponentsRequest as CoreLyapunovExponentsRequest,
@@ -16,6 +19,7 @@ import type { JobTiming } from '../compute/jobQueue'
 import { createSystem } from '../system/model'
 import type {
   AnalysisObject,
+  AnalysisViewport,
   BifurcationDiagram,
   ContinuationObject,
   ContinuationPoint,
@@ -44,6 +48,7 @@ import type {
 } from '../system/types'
 import type { LoadedEntities, SystemStore } from '../system/store'
 import {
+  addAnalysisViewport,
   addBifurcationDiagram,
   addBranch,
   addObject,
@@ -57,6 +62,7 @@ import {
   selectNode,
   toggleNodeExpanded,
   toggleNodeVisibility,
+  updateAnalysisViewport,
   updateBifurcationDiagram,
   updateLimitCycleRenderTarget,
   updateLayout,
@@ -1438,6 +1444,10 @@ type AppActions = {
     update: Partial<Omit<IsoclineObject, 'type' | 'name' | 'systemName'>>
   ) => void
   updateScene: (sceneId: string, update: Partial<Omit<Scene, 'id' | 'name'>>) => void
+  updateAnalysisViewport: (
+    viewportId: string,
+    update: Partial<Omit<AnalysisViewport, 'id' | 'name'>>
+  ) => void
   updateBifurcationDiagram: (
     diagramId: string,
     update: Partial<Omit<BifurcationDiagram, 'id' | 'name'>>
@@ -1460,6 +1470,14 @@ type AppActions = {
     request: SampleMap1DFunctionRequest,
     opts?: { signal?: AbortSignal }
   ) => Promise<SampleMap1DFunctionResult>
+  computeEventSeriesFromOrbit: (
+    request: ComputeEventSeriesFromOrbitRequest,
+    opts?: { signal?: AbortSignal }
+  ) => Promise<EventSeriesResult>
+  computeEventSeriesFromSamples: (
+    request: ComputeEventSeriesFromSamplesRequest,
+    opts?: { signal?: AbortSignal }
+  ) => Promise<EventSeriesResult>
   computeLyapunovExponents: (request: OrbitLyapunovRequest) => Promise<void>
   computeCovariantLyapunovVectors: (request: OrbitCovariantLyapunovRequest) => Promise<void>
   computeLimitCycleFloquetModes: (request: LimitCycleFloquetModesRequest) => Promise<void>
@@ -1487,6 +1505,7 @@ type AppActions = {
     request: HomoclinicFromHomotopySaddleRequest
   ) => Promise<void>
   addScene: (name: string, targetId?: string | null) => Promise<void>
+  addAnalysisViewport: (name: string, targetId?: string | null) => Promise<void>
   addBifurcationDiagram: (name: string, targetId?: string | null) => Promise<void>
   importSystem: (file: File) => Promise<void>
   ensureObjectLoaded: (id: string) => Promise<void>
@@ -1853,7 +1872,7 @@ export function AppProvider({
       }
       const system = renameNode(state.system, nodeId, trimmedName)
       dispatch({ type: 'SET_SYSTEM', system })
-      if (node.kind === 'scene' || node.kind === 'diagram') {
+      if (node.kind === 'scene' || node.kind === 'diagram' || node.kind === 'analysis') {
         scheduleUiSave(system)
       } else {
         scheduleSystemSave(system)
@@ -2210,6 +2229,16 @@ export function AppProvider({
     [scheduleUiSave, state.system]
   )
 
+  const updateAnalysisViewportAction = useCallback(
+    (viewportId: string, update: Partial<Omit<AnalysisViewport, 'id' | 'name'>>) => {
+      if (!state.system) return
+      const system = updateAnalysisViewport(state.system, viewportId, update)
+      dispatch({ type: 'SET_SYSTEM', system })
+      scheduleUiSave(system)
+    },
+    [scheduleUiSave, state.system]
+  )
+
   const duplicateNodeAction = useCallback(
     async (nodeId: string) => {
       if (!state.system) return
@@ -2230,7 +2259,11 @@ export function AppProvider({
         const selected = selectNode(duplicated.system, duplicated.nodeId)
         dispatch({ type: 'SET_SYSTEM', system: selected })
         const duplicatedNode = selected.nodes[duplicated.nodeId]
-        if (duplicatedNode?.kind === 'scene' || duplicatedNode?.kind === 'diagram') {
+        if (
+          duplicatedNode?.kind === 'scene' ||
+          duplicatedNode?.kind === 'diagram' ||
+          duplicatedNode?.kind === 'analysis'
+        ) {
           await store.saveUi(selected)
         } else {
           await store.save(selected)
@@ -2250,10 +2283,15 @@ export function AppProvider({
       if (!state.system) return
       dispatch({ type: 'SET_BUSY', busy: true })
       try {
+        const node = state.system.nodes[nodeId]
         const system = removeNode(state.system, nodeId)
         dispatch({ type: 'SET_SYSTEM', system })
         dispatch({ type: 'REMOVE_ISOCLINE_GEOMETRY', isoclineId: nodeId })
-        await store.save(system)
+        if (node?.kind === 'scene' || node?.kind === 'diagram' || node?.kind === 'analysis') {
+          await store.saveUi(system)
+        } else {
+          await store.save(system)
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         dispatch({ type: 'SET_ERROR', error: message })
@@ -2382,6 +2420,38 @@ export function AppProvider({
     async (request: SampleMap1DFunctionRequest, opts?: { signal?: AbortSignal }) => {
       try {
         return await client.sampleMap1DFunction(request, opts)
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          throw err
+        }
+        const message = err instanceof Error ? err.message : String(err)
+        dispatch({ type: 'SET_ERROR', error: message })
+        throw err
+      }
+    },
+    [client]
+  )
+
+  const computeEventSeriesFromOrbit = useCallback(
+    async (request: ComputeEventSeriesFromOrbitRequest, opts?: { signal?: AbortSignal }) => {
+      try {
+        return await client.computeEventSeriesFromOrbit(request, opts)
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          throw err
+        }
+        const message = err instanceof Error ? err.message : String(err)
+        dispatch({ type: 'SET_ERROR', error: message })
+        throw err
+      }
+    },
+    [client]
+  )
+
+  const computeEventSeriesFromSamples = useCallback(
+    async (request: ComputeEventSeriesFromSamplesRequest, opts?: { signal?: AbortSignal }) => {
+      try {
+        return await client.computeEventSeriesFromSamples(request, opts)
       } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') {
           throw err
@@ -6800,6 +6870,33 @@ export function AppProvider({
     [state.system, store]
   )
 
+  const addAnalysisViewportAction = useCallback(
+    async (name: string, targetId?: string | null) => {
+      if (!state.system) return
+      dispatch({ type: 'SET_BUSY', busy: true })
+      try {
+        const trimmedName = name.trim()
+        const nameError = validateObjectName(trimmedName, 'Analysis viewport')
+        if (nameError) {
+          throw new Error(nameError)
+        }
+        const created = addAnalysisViewport(state.system, trimmedName)
+        const updated =
+          targetId && targetId !== created.nodeId
+            ? reorderNode(created.system, created.nodeId, targetId)
+            : created.system
+        dispatch({ type: 'SET_SYSTEM', system: updated })
+        await store.saveUi(updated)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        dispatch({ type: 'SET_ERROR', error: message })
+      } finally {
+        dispatch({ type: 'SET_BUSY', busy: false })
+      }
+    },
+    [state.system, store]
+  )
+
   const importSystem = useCallback(
     async (file: File) => {
       dispatch({ type: 'SET_BUSY', busy: true })
@@ -6838,6 +6935,7 @@ export function AppProvider({
       updateObjectFrozenVariables: updateObjectFrozenVariablesAction,
       updateIsoclineObject: updateIsoclineObjectAction,
       updateScene: updateSceneAction,
+      updateAnalysisViewport: updateAnalysisViewportAction,
       updateBifurcationDiagram: updateBifurcationDiagramAction,
       setLimitCycleRenderTarget: setLimitCycleRenderTargetAction,
       duplicateNode: duplicateNodeAction,
@@ -6848,6 +6946,8 @@ export function AppProvider({
       runOrbit,
       computeIsocline,
       sampleMap1DFunction,
+      computeEventSeriesFromOrbit,
+      computeEventSeriesFromSamples,
       computeLyapunovExponents,
       computeCovariantLyapunovVectors,
       computeLimitCycleFloquetModes,
@@ -6871,6 +6971,7 @@ export function AppProvider({
       createHomotopySaddleFromEquilibrium,
       createHomoclinicFromHomotopySaddle,
       addScene: addSceneAction,
+      addAnalysisViewport: addAnalysisViewportAction,
       addBifurcationDiagram: addBifurcationDiagramAction,
       importSystem,
       ensureObjectLoaded,
@@ -6885,6 +6986,8 @@ export function AppProvider({
       createOrbitObject,
       runOrbit,
       sampleMap1DFunction,
+      computeEventSeriesFromOrbit,
+      computeEventSeriesFromSamples,
       computeLyapunovExponents,
       computeCovariantLyapunovVectors,
       computeLimitCycleFloquetModes,
@@ -6930,6 +7033,7 @@ export function AppProvider({
       updateObjectFrozenVariablesAction,
       updateIsoclineObjectAction,
       updateSceneAction,
+      updateAnalysisViewportAction,
       updateBifurcationDiagramAction,
       setLimitCycleRenderTargetAction,
       duplicateNodeAction,
@@ -6937,6 +7041,7 @@ export function AppProvider({
       createIsoclineObject,
       computeIsocline,
       addSceneAction,
+      addAnalysisViewportAction,
       importSystem,
       ensureObjectLoaded,
       ensureBranchLoaded,

--- a/web/src/state/appState.tsx
+++ b/web/src/state/appState.tsx
@@ -1478,6 +1478,14 @@ type AppActions = {
     request: ComputeEventSeriesFromSamplesRequest,
     opts?: { signal?: AbortSignal }
   ) => Promise<EventSeriesResult>
+  validateAnalysisExpression: (
+    request: {
+      system: SystemConfig
+      expression: string
+      role: 'event' | 'observable'
+    },
+    opts?: { signal?: AbortSignal }
+  ) => Promise<void>
   computeLyapunovExponents: (request: OrbitLyapunovRequest) => Promise<void>
   computeCovariantLyapunovVectors: (request: OrbitCovariantLyapunovRequest) => Promise<void>
   computeLimitCycleFloquetModes: (request: LimitCycleFloquetModesRequest) => Promise<void>
@@ -2433,33 +2441,41 @@ export function AppProvider({
   )
 
   const computeEventSeriesFromOrbit = useCallback(
-    async (request: ComputeEventSeriesFromOrbitRequest, opts?: { signal?: AbortSignal }) => {
-      try {
-        return await client.computeEventSeriesFromOrbit(request, opts)
-      } catch (err) {
-        if (err instanceof Error && err.name === 'AbortError') {
-          throw err
-        }
-        const message = err instanceof Error ? err.message : String(err)
-        dispatch({ type: 'SET_ERROR', error: message })
-        throw err
-      }
-    },
+    async (request: ComputeEventSeriesFromOrbitRequest, opts?: { signal?: AbortSignal }) =>
+      await client.computeEventSeriesFromOrbit(request, opts),
     [client]
   )
 
   const computeEventSeriesFromSamples = useCallback(
-    async (request: ComputeEventSeriesFromSamplesRequest, opts?: { signal?: AbortSignal }) => {
-      try {
-        return await client.computeEventSeriesFromSamples(request, opts)
-      } catch (err) {
-        if (err instanceof Error && err.name === 'AbortError') {
-          throw err
-        }
-        const message = err instanceof Error ? err.message : String(err)
-        dispatch({ type: 'SET_ERROR', error: message })
-        throw err
+    async (request: ComputeEventSeriesFromSamplesRequest, opts?: { signal?: AbortSignal }) =>
+      await client.computeEventSeriesFromSamples(request, opts),
+    [client]
+  )
+
+  const validateAnalysisExpression = useCallback(
+    async (
+      request: {
+        system: SystemConfig
+        expression: string
+        role: 'event' | 'observable'
+      },
+      opts?: { signal?: AbortSignal }
+    ) => {
+      if (request.expression.trim().length === 0) {
+        throw new Error('Expression is required.')
       }
+      await client.computeEventSeriesFromSamples(
+        {
+          system: request.system,
+          samples: [],
+          mode: 'cross_up',
+          eventExpression: request.role === 'event' ? request.expression : '0',
+          eventLevel: 0,
+          observableExpressions:
+            request.role === 'observable' ? [request.expression] : [],
+        },
+        opts
+      )
     },
     [client]
   )
@@ -6948,6 +6964,7 @@ export function AppProvider({
       sampleMap1DFunction,
       computeEventSeriesFromOrbit,
       computeEventSeriesFromSamples,
+      validateAnalysisExpression,
       computeLyapunovExponents,
       computeCovariantLyapunovVectors,
       computeLimitCycleFloquetModes,
@@ -6988,6 +7005,7 @@ export function AppProvider({
       sampleMap1DFunction,
       computeEventSeriesFromOrbit,
       computeEventSeriesFromSamples,
+      validateAnalysisExpression,
       computeLyapunovExponents,
       computeCovariantLyapunovVectors,
       computeLimitCycleFloquetModes,

--- a/web/src/system/archive.ts
+++ b/web/src/system/archive.ts
@@ -69,6 +69,7 @@ function buildArchiveEntries(system: System): ArchiveFileMap {
     rootIds: [...normalized.rootIds],
     scenes: structuredClone(normalized.scenes),
     bifurcationDiagrams: structuredClone(normalized.bifurcationDiagrams),
+    analysisViewports: structuredClone(normalized.analysisViewports),
     ui: structuredClone(normalized.ui),
   }
   entries['manifest.json'] = encodeJson(manifest)
@@ -192,6 +193,7 @@ export function parseSystemArchiveBytes(raw: Uint8Array): System {
     branches,
     scenes: structuredClone(ui.scenes),
     bifurcationDiagrams: structuredClone(ui.bifurcationDiagrams),
+    analysisViewports: structuredClone(ui.analysisViewports),
     ui: structuredClone(ui.ui),
     updatedAt: meta.updatedAt,
   }

--- a/web/src/system/importExport.test.ts
+++ b/web/src/system/importExport.test.ts
@@ -3,12 +3,14 @@ import { strFromU8, unzipSync } from 'fflate'
 import { downloadSystem, readSystemFile } from './importExport'
 import { buildSystemArchiveBytes } from './archive'
 import {
+  addAnalysisViewport,
   addBifurcationDiagram,
   addBranch,
   addObject,
   addScene,
   createSystem,
   selectNode,
+  updateAnalysisViewport,
   updateLayout,
   updateNodeRender,
   updateViewportHeights,
@@ -256,6 +258,20 @@ function createRichSystem(): {
 
   system = addScene(system, 'Scene_A').system
   system = addBifurcationDiagram(system, 'Diagram_A').system
+  const analysisAdded = addAnalysisViewport(system, 'Return_Map_A')
+  system = updateAnalysisViewport(analysisAdded.system, analysisAdded.nodeId, {
+    sourceNodeIds: [orbitAdded.nodeId, limitCycleAdded.nodeId],
+    event: {
+      mode: 'cross_up',
+      expression: 'mu',
+      level: 0,
+    },
+    axes: {
+      x: { kind: 'observable', expression: 'mu', hitOffset: 0, label: 'mu@n' },
+      y: { kind: 'observable', expression: 'x', hitOffset: 1, label: 'x@n+1' },
+      z: null,
+    },
+  })
   system = updateLayout(system, { leftWidth: 310, rightWidth: 360 })
   system = updateViewportHeights(system, { [limitCycleAdded.nodeId]: 520 })
   system = updateNodeRender(system, limitCycleAdded.nodeId, {
@@ -324,6 +340,7 @@ describe('system import/export (zip)', () => {
     expect(restored.rootIds).toEqual(ids.system.rootIds)
     expect(restored.scenes).toEqual(ids.system.scenes)
     expect(restored.bifurcationDiagrams).toEqual(ids.system.bifurcationDiagrams)
+    expect(restored.analysisViewports).toEqual(ids.system.analysisViewports)
     expect(Object.keys(restored.index.objects).sort()).toEqual(
       Object.keys(ids.system.index.objects).sort()
     )
@@ -377,6 +394,7 @@ describe('system import/export (zip)', () => {
       const loaded = await opfs.load(imported.id)
 
       expect(loaded.name).toBe(ids.system.name)
+      expect(loaded.analysisViewports).toEqual(ids.system.analysisViewports)
       expect(Object.keys(loaded.index.objects).sort()).toEqual(
         Object.keys(ids.system.index.objects).sort()
       )

--- a/web/src/system/importExport.test.ts
+++ b/web/src/system/importExport.test.ts
@@ -263,7 +263,7 @@ function createRichSystem(): {
     sourceNodeIds: [orbitAdded.nodeId, limitCycleAdded.nodeId],
     event: {
       mode: 'cross_up',
-      expression: 'mu',
+      source: { kind: 'custom', expression: 'mu' },
       level: 0,
     },
     axes: {

--- a/web/src/system/indexedDb.test.ts
+++ b/web/src/system/indexedDb.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import { IndexedDbSystemStore } from './indexedDb'
-import { addObject, createSystem, updateLayout, updateObject, updateSystem } from './model'
+import {
+  addAnalysisViewport,
+  addObject,
+  createSystem,
+  updateAnalysisViewport,
+  updateLayout,
+  updateObject,
+  updateSystem,
+} from './model'
 import type { OrbitObject } from './types'
 
 async function createLegacyDb(name: string, version = 1): Promise<void> {
@@ -102,19 +110,27 @@ describe('IndexedDbSystemStore', () => {
     const store = makeStore()
     try {
       const base = createSystem({ name: 'IndexedDB_System' })
-      await store.save(base)
+      const analysisAdded = addAnalysisViewport(base, 'Return_Map')
+      const baseWithAnalysis = updateAnalysisViewport(analysisAdded.system, analysisAdded.nodeId, {
+        sourceNodeIds: [analysisAdded.nodeId],
+      })
+      await store.save(baseWithAnalysis)
 
-      const updated = updateSystem(base, { ...base.config, name: 'IndexedDB_System_Updated' })
+      const updated = updateSystem(baseWithAnalysis, {
+        ...baseWithAnalysis.config,
+        name: 'IndexedDB_System_Updated',
+      })
       await store.save(updated)
 
-      const uiOnly = updateLayout(base, {
-        leftWidth: base.ui.layout.leftWidth + 20,
+      const uiOnly = updateLayout(baseWithAnalysis, {
+        leftWidth: baseWithAnalysis.ui.layout.leftWidth + 20,
       })
       await store.saveUi(uiOnly)
 
-      const loaded = await store.load(base.id)
+      const loaded = await store.load(baseWithAnalysis.id)
       expect(loaded.name).toBe('IndexedDB_System_Updated')
       expect(loaded.ui.layout.leftWidth).toBe(uiOnly.ui.layout.leftWidth)
+      expect(loaded.analysisViewports).toEqual(baseWithAnalysis.analysisViewports)
     } finally {
       await store.clear()
     }

--- a/web/src/system/indexedDb.ts
+++ b/web/src/system/indexedDb.ts
@@ -149,6 +149,7 @@ function buildUiRecord(system: System): UiRecord {
       rootIds: [...system.rootIds],
       scenes: structuredClone(system.scenes),
       bifurcationDiagrams: structuredClone(system.bifurcationDiagrams),
+      analysisViewports: structuredClone(system.analysisViewports),
       ui: structuredClone(system.ui),
     },
   }
@@ -295,6 +296,7 @@ function buildSkeletonSystem(
     branches: {},
     scenes: structuredClone(ui.scenes),
     bifurcationDiagrams: structuredClone(ui.bifurcationDiagrams),
+    analysisViewports: structuredClone(ui.analysisViewports),
     ui: structuredClone(ui.ui),
     updatedAt: meta.updatedAt,
   })

--- a/web/src/system/model.test.ts
+++ b/web/src/system/model.test.ts
@@ -715,7 +715,7 @@ describe('system model', () => {
       viewRevision: 6,
       event: {
         mode: 'cross_down',
-        expression: 'mu',
+        source: { kind: 'custom', expression: 'mu' },
         level: 0.25,
       },
       axes: {
@@ -752,7 +752,7 @@ describe('system model', () => {
       viewRevision: 6,
       event: {
         mode: 'cross_down',
-        expression: 'mu',
+        source: { kind: 'custom', expression: 'mu' },
         level: 0.25,
       },
       axes: {

--- a/web/src/system/model.test.ts
+++ b/web/src/system/model.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
+  addAnalysisViewport,
   addBranch,
   addObject,
   addBifurcationDiagram,
@@ -8,10 +9,12 @@ import {
   duplicateNode,
   moveNode,
   normalizeSystem,
+  removeNode,
   reorderNode,
   renameNode,
   selectNode,
   toggleNodeVisibility,
+  updateAnalysisViewport,
   updateBifurcationDiagram,
   updateNodeRender,
   updateScene,
@@ -136,14 +139,17 @@ describe('system model', () => {
     const system = createSystem({ name: 'Legacy' })
     const { system: withScene } = addScene(system, 'Scene')
     const { system: withDiagram } = addBifurcationDiagram(withScene, 'Diagram')
-    const legacy = structuredClone(withDiagram) as typeof withDiagram
+    const { system: withAnalysis } = addAnalysisViewport(withDiagram, 'Return_Map')
+    const legacy = structuredClone(withAnalysis) as typeof withAnalysis
     delete (legacy.scenes[0] as { viewRevision?: number }).viewRevision
     delete (legacy.bifurcationDiagrams[0] as { viewRevision?: number }).viewRevision
+    delete (legacy.analysisViewports[0] as { viewRevision?: number }).viewRevision
 
     const normalized = normalizeSystem(legacy)
 
     expect(normalized.scenes[0].viewRevision).toBe(0)
     expect(normalized.bifurcationDiagrams[0].viewRevision).toBe(0)
+    expect(normalized.analysisViewports[0].viewRevision).toBe(0)
   })
 
   it('keeps viewRevision stable across non-view updates', () => {
@@ -312,6 +318,31 @@ describe('system model', () => {
     expect(renamed.objects).toBe(withScene.system.objects)
     expect(renamed.branches).toBe(withScene.system.branches)
     expect(renamed.rootIds).toBe(withScene.system.rootIds)
+  })
+
+  it('renames analysis viewport nodes without cloning object or branch payload maps', () => {
+    const base = createSystem({ name: 'Analysis_Rename_Ref' })
+    const orbit: OrbitObject = {
+      type: 'orbit',
+      name: 'Orbit A',
+      systemName: base.config.name,
+      data: [[0, 0, 1]],
+      t_start: 0,
+      t_end: 0,
+      dt: 0.1,
+    }
+    const withObject = addObject(base, orbit)
+    const withAnalysis = addAnalysisViewport(withObject.system, 'Return Map A')
+
+    const renamed = renameNode(withAnalysis.system, withAnalysis.nodeId, 'Return Map B')
+
+    expect(renamed.nodes[withAnalysis.nodeId].name).toBe('Return Map B')
+    expect(
+      renamed.analysisViewports.find((viewport) => viewport.id === withAnalysis.nodeId)?.name
+    ).toBe('Return Map B')
+    expect(renamed.objects).toBe(withAnalysis.system.objects)
+    expect(renamed.branches).toBe(withAnalysis.system.branches)
+    expect(renamed.rootIds).toBe(withAnalysis.system.rootIds)
   })
 
   it('renames objects with dependency rewrites using copy-on-write updates', () => {
@@ -674,4 +705,100 @@ describe('system model', () => {
       viewRevision: 4,
     })
   })
+  it('duplicates analysis viewports as siblings with copied UI state', () => {
+    let system = createSystem({ name: 'Duplicate_Analysis_Viewport' })
+    const analysisAdded = addAnalysisViewport(system, 'Return_Map_A')
+    system = updateAnalysisViewport(analysisAdded.system, analysisAdded.nodeId, {
+      sourceNodeIds: ['node-1'],
+      display: 'selection',
+      axisRanges: { x: [-1, 1], y: [0, 2] },
+      viewRevision: 6,
+      event: {
+        mode: 'cross_down',
+        expression: 'mu',
+        level: 0.25,
+      },
+      axes: {
+        x: { kind: 'observable', expression: 'mu', hitOffset: 0, label: 'mu@n' },
+        y: { kind: 'observable', expression: 'x', hitOffset: 1, label: 'x@n+1' },
+        z: { kind: 'hit_index', label: 'n' },
+      },
+      advanced: {
+        skipHits: 2,
+        hitStride: 3,
+        maxHits: 120,
+        connectPoints: true,
+      },
+    })
+    system.ui.viewportHeights[analysisAdded.nodeId] = 260
+
+    const analysisDuplicate = duplicateNode(system, analysisAdded.nodeId)
+    expect(analysisDuplicate).toBeTruthy()
+    if (!analysisDuplicate) {
+      throw new Error('Expected duplicated analysis viewport.')
+    }
+    const duplicatedAnalysisId = analysisDuplicate.nodeId
+    const analysisRootIndex = analysisDuplicate.system.rootIds.indexOf(analysisAdded.nodeId)
+    expect(analysisDuplicate.system.rootIds[analysisRootIndex + 1]).toBe(duplicatedAnalysisId)
+    expect(analysisDuplicate.system.nodes[duplicatedAnalysisId].name).toBe('Return_Map_A_copy')
+    expect(analysisDuplicate.system.ui.viewportHeights[duplicatedAnalysisId]).toBe(260)
+    expect(
+      analysisDuplicate.system.analysisViewports.find((viewport) => viewport.id === duplicatedAnalysisId)
+    ).toMatchObject({
+      name: 'Return_Map_A_copy',
+      sourceNodeIds: [],
+      display: 'selection',
+      axisRanges: { x: [-1, 1], y: [0, 2] },
+      viewRevision: 6,
+      event: {
+        mode: 'cross_down',
+        expression: 'mu',
+        level: 0.25,
+      },
+      axes: {
+        x: { kind: 'observable', expression: 'mu', hitOffset: 0, label: 'mu@n' },
+        y: { kind: 'observable', expression: 'x', hitOffset: 1, label: 'x@n+1' },
+        z: { kind: 'hit_index', label: 'n' },
+      },
+      advanced: {
+        skipHits: 2,
+        hitStride: 3,
+        maxHits: 120,
+        connectPoints: true,
+      },
+    })
+  })
+
+  it('removes deleted source nodes from analysis viewport source selections', () => {
+    const base = createSystem({ name: 'Analysis_Remove_Cleanup' })
+    const orbitA: OrbitObject = {
+      type: 'orbit',
+      name: 'Orbit_A',
+      systemName: base.config.name,
+      data: [[0, 0, 1]],
+      t_start: 0,
+      t_end: 0,
+      dt: 0.1,
+    }
+    const orbitB: OrbitObject = {
+      type: 'orbit',
+      name: 'Orbit_B',
+      systemName: base.config.name,
+      data: [[0, 1, 0]],
+      t_start: 0,
+      t_end: 0,
+      dt: 0.1,
+    }
+    const withOrbitA = addObject(base, orbitA)
+    const withOrbitB = addObject(withOrbitA.system, orbitB)
+    const analysisAdded = addAnalysisViewport(withOrbitB.system, 'Return_Map')
+    const configured = updateAnalysisViewport(analysisAdded.system, analysisAdded.nodeId, {
+      sourceNodeIds: [withOrbitA.nodeId, withOrbitB.nodeId],
+    })
+
+    const cleaned = removeNode(configured, withOrbitA.nodeId)
+
+    expect(cleaned.analysisViewports[0]?.sourceNodeIds).toEqual([withOrbitB.nodeId])
+  })
+
 })

--- a/web/src/system/model.ts
+++ b/web/src/system/model.ts
@@ -64,7 +64,10 @@ const DEFAULT_SCENE: Scene = {
 
 const DEFAULT_ANALYSIS_EVENT: AnalysisEventSpec = {
   mode: 'cross_up',
-  expression: 'x',
+  source: {
+    kind: 'custom',
+    expression: 'x',
+  },
   level: 0,
 }
 
@@ -77,7 +80,7 @@ const DEFAULT_ANALYSIS_ADVANCED: AnalysisViewportAdvanced = {
 
 function defaultObservableAxis(
   expression: string,
-  hitOffset: -1 | 0 | 1,
+  hitOffset: number,
   label?: string
 ): AnalysisAxisSpec {
   return {
@@ -107,7 +110,10 @@ function defaultReturnMapViewport(
       event: {
         ...DEFAULT_ANALYSIS_EVENT,
         mode: 'every_iterate',
-        expression: firstVar,
+        source: {
+          kind: 'custom',
+          expression: firstVar,
+        },
       },
       axes: {
         x: defaultObservableAxis(firstVar, 0, `${firstVar}@n`),
@@ -131,7 +137,10 @@ function defaultReturnMapViewport(
     display: 'all',
     event: {
       ...DEFAULT_ANALYSIS_EVENT,
-      expression: firstVar,
+      source: {
+        kind: 'custom',
+        expression: firstVar,
+      },
     },
     axes: {
       x: defaultObservableAxis(xExpression, 0, `${xExpression}@n`),
@@ -631,17 +640,76 @@ function isAnalysisSourceNode(
 function normalizeAnalysisAxis(axis: AnalysisAxisSpec | null | undefined): AnalysisAxisSpec {
   if (!axis || axis.kind === 'hit_index' || axis.kind === 'delta_time') {
     return axis?.kind === 'delta_time'
-      ? { kind: 'delta_time', label: axis.label ?? null }
+      ? {
+          kind: 'delta_time',
+          hitOffset:
+            typeof axis.hitOffset === 'number' && Number.isFinite(axis.hitOffset)
+              ? Math.trunc(axis.hitOffset)
+              : 0,
+          label: axis.label ?? null,
+        }
       : axis?.kind === 'hit_index'
         ? { kind: 'hit_index', label: axis.label ?? null }
         : defaultObservableAxis('x', 0)
   }
-  const hitOffset = axis.hitOffset === -1 || axis.hitOffset === 1 ? axis.hitOffset : 0
+  const hitOffset =
+    typeof axis.hitOffset === 'number' && Number.isFinite(axis.hitOffset)
+      ? Math.trunc(axis.hitOffset)
+      : 0
   return {
     kind: 'observable',
-    expression: axis.expression || 'x',
+    expression: typeof axis.expression === 'string' ? axis.expression : 'x',
     hitOffset,
     label: axis.label ?? null,
+  }
+}
+
+function normalizeAnalysisEventSource(
+  system: Pick<System, 'config'>,
+  source: AnalysisEventSpec['source'] | null | undefined,
+  legacyExpression?: unknown
+): AnalysisEventSpec['source'] {
+  const firstVar = system.config.varNames[0] ?? 'x'
+  if (source?.kind === 'custom') {
+    return {
+      kind: 'custom',
+      expression:
+        typeof source.expression === 'string'
+          ? source.expression
+          : typeof legacyExpression === 'string'
+            ? legacyExpression
+            : firstVar,
+    }
+  }
+  if (
+    source?.kind === 'flow_derivative' &&
+    system.config.type === 'flow' &&
+    system.config.varNames.includes(source.variableName)
+  ) {
+    return {
+      kind: 'flow_derivative',
+      variableName: source.variableName,
+    }
+  }
+  if (
+    source?.kind === 'map_increment' &&
+    system.config.type === 'map' &&
+    system.config.varNames.includes(source.variableName)
+  ) {
+    return {
+      kind: 'map_increment',
+      variableName: source.variableName,
+    }
+  }
+  if (typeof legacyExpression === 'string') {
+    return {
+      kind: 'custom',
+      expression: legacyExpression,
+    }
+  }
+  return {
+    kind: 'custom',
+    expression: firstVar,
   }
 }
 
@@ -673,6 +741,7 @@ function normalizeAnalysisViewport(
   viewport: AnalysisViewport
 ): AnalysisViewport {
   const fallback = defaultReturnMapViewport(system.config, viewport.id, viewport.name)
+  const legacyEvent = viewport.event as (AnalysisEventSpec & { expression?: unknown }) | undefined
   const sourceNodeIds = Array.isArray(viewport.sourceNodeIds)
     ? viewport.sourceNodeIds.filter((nodeId) => isAnalysisSourceNode(system, nodeId))
     : []
@@ -684,7 +753,7 @@ function normalizeAnalysisViewport(
       viewport.event?.mode === 'cross_either'
         ? viewport.event.mode
         : fallback.event.mode,
-    expression: viewport.event?.expression || fallback.event.expression,
+    source: normalizeAnalysisEventSource(system, viewport.event?.source, legacyEvent?.expression),
     level:
       typeof viewport.event?.level === 'number' && Number.isFinite(viewport.event.level)
         ? viewport.event.level

--- a/web/src/system/model.ts
+++ b/web/src/system/model.ts
@@ -1,5 +1,9 @@
 import type {
+  AnalysisAxisSpec,
   AnalysisObject,
+  AnalysisViewport,
+  AnalysisViewportAdvanced,
+  AnalysisEventSpec,
   BifurcationAxis,
   BifurcationDiagram,
   ContinuationObject,
@@ -56,6 +60,86 @@ const DEFAULT_SCENE: Scene = {
   axisVariables: null,
   selectedNodeIds: [],
   display: 'all',
+}
+
+const DEFAULT_ANALYSIS_EVENT: AnalysisEventSpec = {
+  mode: 'cross_up',
+  expression: 'x',
+  level: 0,
+}
+
+const DEFAULT_ANALYSIS_ADVANCED: AnalysisViewportAdvanced = {
+  skipHits: 0,
+  hitStride: 1,
+  maxHits: 2000,
+  connectPoints: false,
+}
+
+function defaultObservableAxis(
+  expression: string,
+  hitOffset: -1 | 0 | 1,
+  label?: string
+): AnalysisAxisSpec {
+  return {
+    kind: 'observable',
+    expression,
+    hitOffset,
+    label,
+  }
+}
+
+function defaultReturnMapViewport(
+  config: SystemConfig,
+  id: string,
+  name: string
+): AnalysisViewport {
+  const firstVar = config.varNames[0] ?? 'x'
+  const remaining = config.varNames.filter((varName) => varName !== firstVar)
+  if (config.type === 'map') {
+    return {
+      id,
+      name,
+      kind: 'return_map',
+      axisRanges: {},
+      viewRevision: 0,
+      sourceNodeIds: [],
+      display: 'all',
+      event: {
+        ...DEFAULT_ANALYSIS_EVENT,
+        mode: 'every_iterate',
+        expression: firstVar,
+      },
+      axes: {
+        x: defaultObservableAxis(firstVar, 0, `${firstVar}@n`),
+        y: defaultObservableAxis(firstVar, 1, `${firstVar}@n+1`),
+        z: null,
+      },
+      advanced: structuredClone(DEFAULT_ANALYSIS_ADVANCED),
+    }
+  }
+
+  const xExpression = remaining[0] ?? firstVar
+  const yExpression = remaining[1] ?? remaining[0] ?? firstVar
+  const yOffset: -1 | 0 | 1 = remaining.length >= 2 ? 0 : 1
+  return {
+    id,
+    name,
+    kind: 'return_map',
+    axisRanges: {},
+    viewRevision: 0,
+    sourceNodeIds: [],
+    display: 'all',
+    event: {
+      ...DEFAULT_ANALYSIS_EVENT,
+      expression: firstVar,
+    },
+    axes: {
+      x: defaultObservableAxis(xExpression, 0, `${xExpression}@n`),
+      y: defaultObservableAxis(yExpression, yOffset, `${yExpression}@${yOffset === 0 ? 'n' : 'n+1'}`),
+      z: null,
+    },
+    advanced: structuredClone(DEFAULT_ANALYSIS_ADVANCED),
+  }
 }
 
 export const DEFAULT_RENDER: RenderStyle = {
@@ -128,6 +212,7 @@ export function createSystem(args: { name: string; config?: SystemConfig }): Sys
     branches: {},
     scenes: [],
     bifurcationDiagrams: [],
+    analysisViewports: [],
     ui: structuredClone(DEFAULT_UI),
     updatedAt: nowIso(),
   }
@@ -324,6 +409,26 @@ export function addBifurcationDiagram(
   return { system: next, nodeId: node.id }
 }
 
+export function addAnalysisViewport(
+  system: System,
+  name: string
+): { system: System; nodeId: string } {
+  const next = structuredClone(system)
+  const analysisId = makeId('analysis')
+  const node = createTreeNode({
+    id: analysisId,
+    name,
+    kind: 'analysis',
+    objectType: 'analysis',
+    parentId: null,
+  })
+  next.nodes[node.id] = node
+  next.rootIds.push(node.id)
+  next.analysisViewports.push(defaultReturnMapViewport(next.config, analysisId, name))
+  next.updatedAt = nowIso()
+  return { system: next, nodeId: node.id }
+}
+
 export function renameNode(system: System, nodeId: string, newName: string): System {
   const node = system.nodes[nodeId]
   if (!node) return system
@@ -376,6 +481,16 @@ export function renameNode(system: System, nodeId: string, newName: string): Sys
     }
   }
 
+  const analysisIndex = system.analysisViewports.findIndex((entry) => entry.id === nodeId)
+  let nextAnalysisViewports = system.analysisViewports
+  if (analysisIndex !== -1) {
+    nextAnalysisViewports = [...system.analysisViewports]
+    nextAnalysisViewports[analysisIndex] = {
+      ...nextAnalysisViewports[analysisIndex],
+      name: newName,
+    }
+  }
+
   return {
     ...system,
     index: nextIndex,
@@ -384,6 +499,7 @@ export function renameNode(system: System, nodeId: string, newName: string): Sys
     branches: nextBranches,
     scenes: nextScenes,
     bifurcationDiagrams: nextBifurcationDiagrams,
+    analysisViewports: nextAnalysisViewports,
     updatedAt,
   }
 }
@@ -497,9 +613,104 @@ function branchParentKey(parentObjectId: string | undefined, parentObjectName: s
   return `name:${parentObjectName}`
 }
 
+function isAnalysisSourceNode(
+  system: Pick<System, 'nodes' | 'branches' | 'index'>,
+  nodeId: string
+): boolean {
+  const node = system.nodes[nodeId]
+  if (!node) return false
+  if (node.kind === 'object') {
+    return node.objectType === 'orbit' || node.objectType === 'limit_cycle'
+  }
+  if (node.kind !== 'branch') return false
+  const branchType =
+    system.branches[nodeId]?.branchType ?? system.index.branches[nodeId]?.branchType ?? null
+  return branchType === 'eq_manifold_1d'
+}
+
+function normalizeAnalysisAxis(axis: AnalysisAxisSpec | null | undefined): AnalysisAxisSpec {
+  if (!axis || axis.kind === 'hit_index' || axis.kind === 'delta_time') {
+    return axis?.kind === 'delta_time'
+      ? { kind: 'delta_time', label: axis.label ?? null }
+      : axis?.kind === 'hit_index'
+        ? { kind: 'hit_index', label: axis.label ?? null }
+        : defaultObservableAxis('x', 0)
+  }
+  const hitOffset = axis.hitOffset === -1 || axis.hitOffset === 1 ? axis.hitOffset : 0
+  return {
+    kind: 'observable',
+    expression: axis.expression || 'x',
+    hitOffset,
+    label: axis.label ?? null,
+  }
+}
+
+function normalizeAnalysisAdvanced(
+  advanced: Partial<AnalysisViewportAdvanced> | null | undefined
+): AnalysisViewportAdvanced {
+  const skipHits =
+    typeof advanced?.skipHits === 'number' && Number.isFinite(advanced.skipHits)
+      ? Math.max(0, Math.floor(advanced.skipHits))
+      : DEFAULT_ANALYSIS_ADVANCED.skipHits
+  const hitStride =
+    typeof advanced?.hitStride === 'number' && Number.isFinite(advanced.hitStride)
+      ? Math.max(1, Math.floor(advanced.hitStride))
+      : DEFAULT_ANALYSIS_ADVANCED.hitStride
+  const maxHits =
+    typeof advanced?.maxHits === 'number' && Number.isFinite(advanced.maxHits)
+      ? Math.max(1, Math.floor(advanced.maxHits))
+      : DEFAULT_ANALYSIS_ADVANCED.maxHits
+  return {
+    skipHits,
+    hitStride,
+    maxHits,
+    connectPoints: Boolean(advanced?.connectPoints),
+  }
+}
+
+function normalizeAnalysisViewport(
+  system: Pick<System, 'config' | 'nodes' | 'branches' | 'index'>,
+  viewport: AnalysisViewport
+): AnalysisViewport {
+  const fallback = defaultReturnMapViewport(system.config, viewport.id, viewport.name)
+  const sourceNodeIds = Array.isArray(viewport.sourceNodeIds)
+    ? viewport.sourceNodeIds.filter((nodeId) => isAnalysisSourceNode(system, nodeId))
+    : []
+  const event = {
+    mode:
+      viewport.event?.mode === 'every_iterate' ||
+      viewport.event?.mode === 'cross_up' ||
+      viewport.event?.mode === 'cross_down' ||
+      viewport.event?.mode === 'cross_either'
+        ? viewport.event.mode
+        : fallback.event.mode,
+    expression: viewport.event?.expression || fallback.event.expression,
+    level:
+      typeof viewport.event?.level === 'number' && Number.isFinite(viewport.event.level)
+        ? viewport.event.level
+        : fallback.event.level,
+  }
+  return {
+    ...fallback,
+    ...viewport,
+    sourceNodeIds,
+    display: viewport.display === 'selection' ? 'selection' : 'all',
+    axisRanges: viewport.axisRanges ?? {},
+    viewRevision: viewport.viewRevision ?? 0,
+    event,
+    axes: {
+      x: normalizeAnalysisAxis(viewport.axes?.x),
+      y: normalizeAnalysisAxis(viewport.axes?.y),
+      z: viewport.axes?.z ? normalizeAnalysisAxis(viewport.axes.z) : null,
+    },
+    advanced: normalizeAnalysisAdvanced(viewport.advanced),
+  }
+}
+
 function duplicateNodeId(kind: TreeNode['kind']): string {
   if (kind === 'scene') return makeId('scene')
   if (kind === 'diagram') return makeId('diagram')
+  if (kind === 'analysis') return makeId('analysis')
   return makeId('node')
 }
 
@@ -518,9 +729,13 @@ export function duplicateNode(
   const sourceDiagramsById = new Map(
     system.bifurcationDiagrams.map((diagram) => [diagram.id, diagram])
   )
+  const sourceAnalysisById = new Map(
+    system.analysisViewports.map((viewport) => [viewport.id, viewport])
+  )
   const objectNames = new Set(Object.values(next.objects).map((obj) => obj.name))
   const sceneNames = new Set(next.scenes.map((scene) => scene.name))
   const diagramNames = new Set(next.bifurcationDiagrams.map((diagram) => diagram.name))
+  const analysisNames = new Set(next.analysisViewports.map((viewport) => viewport.name))
 
   const rootName =
     sourceRoot.kind === 'object'
@@ -529,7 +744,9 @@ export function duplicateNode(
         ? duplicateName(sourceRoot.name, sceneNames)
         : sourceRoot.kind === 'diagram'
           ? duplicateName(sourceRoot.name, diagramNames)
-          : sourceRoot.name
+          : sourceRoot.kind === 'analysis'
+            ? duplicateName(sourceRoot.name, analysisNames)
+            : sourceRoot.name
 
   const cloneSubtree = (
     sourceId: string,
@@ -548,6 +765,8 @@ export function duplicateNode(
       nextName = reserveUniqueName(sourceNode.name, sceneNames)
     } else if (sourceNode.kind === 'diagram') {
       nextName = reserveUniqueName(sourceNode.name, diagramNames)
+    } else if (sourceNode.kind === 'analysis') {
+      nextName = reserveUniqueName(sourceNode.name, analysisNames)
     }
 
     const newId = duplicateNodeId(sourceNode.kind)
@@ -600,6 +819,14 @@ export function duplicateNode(
       if (!diagram) return null
       next.bifurcationDiagrams.push({
         ...structuredClone(diagram),
+        id: newId,
+        name: nextName,
+      })
+    } else if (sourceNode.kind === 'analysis') {
+      const viewport = sourceAnalysisById.get(sourceId)
+      if (!viewport) return null
+      next.analysisViewports.push({
+        ...structuredClone(viewport),
         id: newId,
         name: nextName,
       })
@@ -768,6 +995,12 @@ export function removeNode(system: System, nodeId: string): System {
   next.bifurcationDiagrams = next.bifurcationDiagrams.filter(
     (diagram) => !removalSet.has(diagram.id)
   )
+  next.analysisViewports = next.analysisViewports
+    .filter((viewport) => !removalSet.has(viewport.id))
+    .map((viewport) => ({
+      ...viewport,
+      sourceNodeIds: viewport.sourceNodeIds.filter((id) => !removalSet.has(id)),
+    }))
 
   next.scenes = next.scenes.map((scene) => ({
     ...scene,
@@ -922,6 +1155,25 @@ export function updateBifurcationDiagram(
   }
 }
 
+export function updateAnalysisViewport(
+  system: System,
+  viewportId: string,
+  update: Partial<Omit<AnalysisViewport, 'id' | 'name' | 'kind'>>
+): System {
+  const index = system.analysisViewports.findIndex((entry) => entry.id === viewportId)
+  if (index === -1) return system
+  const nextViewports = [...system.analysisViewports]
+  nextViewports[index] = normalizeAnalysisViewport(system, {
+    ...nextViewports[index],
+    ...update,
+  })
+  return {
+    ...system,
+    analysisViewports: nextViewports,
+    updatedAt: nowIso(),
+  }
+}
+
 export function updateSystem(system: System, config: SystemConfig): System {
   const next = structuredClone(system)
   const previousName = next.config.name
@@ -1032,6 +1284,7 @@ export function normalizeSystem(system: System): System {
     index?: SystemIndex
     scenes?: Scene[]
     bifurcationDiagrams?: BifurcationDiagram[]
+    analysisViewports?: AnalysisViewport[]
     ui?: SystemUiState & { layout?: Partial<SystemLayout> }
   }
   const existingIndex = structuredClone(next.index ?? emptySystemIndex())
@@ -1087,6 +1340,14 @@ export function normalizeSystem(system: System): System {
     })
   }
 
+  if (!next.analysisViewports) {
+    next.analysisViewports = []
+  } else {
+    next.analysisViewports = next.analysisViewports.map((viewport) =>
+      normalizeAnalysisViewport(next as System, viewport)
+    )
+  }
+
   const ensureRootNode = (
     id: string,
     name: string,
@@ -1115,6 +1376,9 @@ export function normalizeSystem(system: System): System {
 
   next.bifurcationDiagrams.forEach((diagram) => {
     ensureRootNode(diagram.id, diagram.name, 'diagram', 'bifurcation')
+  })
+  next.analysisViewports.forEach((viewport) => {
+    ensureRootNode(viewport.id, viewport.name, 'analysis', 'analysis')
   })
 
   const objectNameToNodeId = new Map<string, string>()

--- a/web/src/system/opfs.test.ts
+++ b/web/src/system/opfs.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { OpfsSystemStore } from './opfs'
-import { addBranch, addObject, createSystem, updateLayout, updateObject } from './model'
+import {
+  addAnalysisViewport,
+  addBranch,
+  addObject,
+  createSystem,
+  updateAnalysisViewport,
+  updateLayout,
+  updateObject,
+} from './model'
 import type { ContinuationObject, ContinuationSettings, OrbitObject, System } from './types'
 import { installMockOpfs } from '../test/opfsMock'
 import { nowIso } from '../utils/determinism'
@@ -102,9 +110,23 @@ function createOpfsFixture(): {
     params: [...withOrbitB.system.config.params],
   }
   const withBranch = addBranch(withOrbitB.system, branch, withOrbitA.nodeId)
+  const analysisAdded = addAnalysisViewport(withBranch.system, 'Return_Map')
+  const withAnalysis = updateAnalysisViewport(analysisAdded.system, analysisAdded.nodeId, {
+    sourceNodeIds: [withOrbitA.nodeId, withOrbitB.nodeId],
+    event: {
+      mode: 'cross_up',
+      expression: 'x',
+      level: 0,
+    },
+    axes: {
+      x: { kind: 'observable', expression: 'x', hitOffset: 0, label: 'x@n' },
+      y: { kind: 'observable', expression: 'y', hitOffset: 1, label: 'y@n+1' },
+      z: null,
+    },
+  })
 
   return {
-    system: withBranch.system,
+    system: withAnalysis,
     orbitAId: withOrbitA.nodeId,
     orbitBId: withOrbitB.nodeId,
     branchId: withBranch.nodeId,
@@ -135,6 +157,7 @@ describe('OpfsSystemStore v3', () => {
     expect(Object.keys(skeleton.index.branches).sort()).toEqual(
       Object.keys(fixture.system.index.branches).sort()
     )
+    expect(skeleton.analysisViewports).toEqual(fixture.system.analysisViewports)
     expect(skeleton.objects).toEqual({})
     expect(skeleton.branches).toEqual({})
 
@@ -240,5 +263,8 @@ describe('OpfsSystemStore v3', () => {
     expect(getMockFile(root, objectAPath).writeCount).toBe(beforeObjectA)
     expect(getMockFile(root, objectBPath).writeCount).toBe(beforeObjectB)
     expect(getMockFile(root, branchPath).writeCount).toBe(beforeBranch)
+
+    const loaded = await store.load(fixture.system.id)
+    expect(loaded.analysisViewports).toEqual(fixture.system.analysisViewports)
   })
 })

--- a/web/src/system/opfs.test.ts
+++ b/web/src/system/opfs.test.ts
@@ -115,7 +115,7 @@ function createOpfsFixture(): {
     sourceNodeIds: [withOrbitA.nodeId, withOrbitB.nodeId],
     event: {
       mode: 'cross_up',
-      expression: 'x',
+      source: { kind: 'custom', expression: 'x' },
       level: 0,
     },
     axes: {

--- a/web/src/system/opfs.ts
+++ b/web/src/system/opfs.ts
@@ -160,6 +160,7 @@ async function writeUi(dir: FileSystemDirectoryHandle, system: System) {
       rootIds: [...system.rootIds],
       scenes: structuredClone(system.scenes),
       bifurcationDiagrams: structuredClone(system.bifurcationDiagrams),
+      analysisViewports: structuredClone(system.analysisViewports),
       ui: structuredClone(system.ui),
     },
   }
@@ -353,6 +354,7 @@ function buildSkeletonSystem(
     branches: {},
     scenes: structuredClone(ui.scenes),
     bifurcationDiagrams: structuredClone(ui.bifurcationDiagrams),
+    analysisViewports: structuredClone(ui.analysisViewports),
     ui: structuredClone(ui.ui),
     updatedAt: meta.updatedAt,
   })

--- a/web/src/system/serialization.test.ts
+++ b/web/src/system/serialization.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
+  addAnalysisViewport,
   addObject,
   addScene,
   createSystem,
+  updateAnalysisViewport,
   updateLayout,
   updateNodeRender,
   updateViewportHeights,
@@ -33,7 +35,21 @@ describe('system serialization', () => {
       dt: 0.1,
     }
     const { system: withObject, nodeId } = addObject(withScene, orbit)
-    const withLayout = updateLayout(withObject, { leftWidth: 360 })
+    const analysisAdded = addAnalysisViewport(withObject, 'Return Map 1')
+    const withAnalysis = updateAnalysisViewport(analysisAdded.system, analysisAdded.nodeId, {
+      sourceNodeIds: [nodeId],
+      event: {
+        mode: 'cross_up',
+        expression: 'mu',
+        level: 0,
+      },
+      axes: {
+        x: { kind: 'observable', expression: 'mu', hitOffset: 0, label: 'mu@n' },
+        y: { kind: 'observable', expression: 'x', hitOffset: 1, label: 'x@n+1' },
+        z: null,
+      },
+    })
+    const withLayout = updateLayout(withAnalysis, { leftWidth: 360 })
     const viewportId = sceneId
     const withHeights = updateViewportHeights(withLayout, { [viewportId]: 320 })
     const withRender = updateNodeRender(withHeights, nodeId, {
@@ -49,12 +65,17 @@ describe('system serialization', () => {
     expect(restored.nodes[nodeId].render.color).toBe('#ff0000')
     expect(restored.nodes[nodeId].render.lineWidth).toBe(5)
     expect(restored.objects[nodeId].name).toBe('Orbit A')
+    expect(restored.analysisViewports).toEqual(withRender.analysisViewports)
   })
 
   it('merges UI and data bundles back into a system', () => {
     const base = createSystem({ name: 'Split' })
     const { system: withScene, nodeId: sceneId } = addScene(base, 'Scene 1')
-    const withLayout = updateLayout(withScene, { rightWidth: 400 })
+    const analysisAdded = addAnalysisViewport(withScene, 'Return Map 1')
+    const withAnalysis = updateAnalysisViewport(analysisAdded.system, analysisAdded.nodeId, {
+      sourceNodeIds: [sceneId],
+    })
+    const withLayout = updateLayout(withAnalysis, { rightWidth: 400 })
     const viewportId = sceneId
     const withHeights = updateViewportHeights(withLayout, { [viewportId]: 280 })
 
@@ -62,9 +83,11 @@ describe('system serialization', () => {
     const uiBundle = serializeSystemUi(withHeights)
     const merged = mergeSystem(dataBundle.system, uiBundle.ui)
 
+    expect('analysisViewports' in (dataBundle.system as unknown as Record<string, unknown>)).toBe(false)
     expect(merged.ui.layout.rightWidth).toBe(400)
     expect(merged.ui.viewportHeights[viewportId]).toBe(280)
     expect(merged.config.name).toBe('Split')
+    expect(merged.analysisViewports).toEqual(withHeights.analysisViewports)
   })
 
   it('extracts UI from legacy bundles', () => {
@@ -74,6 +97,7 @@ describe('system serialization', () => {
 
     expect(data.id).toBe(system.id)
     expect(ui?.rootIds.length).toBe(0)
+    expect(ui?.analysisViewports).toEqual([])
     expect(ui?.ui.layout.leftWidth).toBe(system.ui.layout.leftWidth)
   })
 

--- a/web/src/system/serialization.test.ts
+++ b/web/src/system/serialization.test.ts
@@ -40,7 +40,7 @@ describe('system serialization', () => {
       sourceNodeIds: [nodeId],
       event: {
         mode: 'cross_up',
-        expression: 'mu',
+        source: { kind: 'custom', expression: 'mu' },
         level: 0,
       },
       axes: {

--- a/web/src/system/serialization.ts
+++ b/web/src/system/serialization.ts
@@ -43,7 +43,7 @@ function unsupportedSchemaError(version: number): Error {
 
 export function splitSystem(system: System): { data: SystemData; ui: SystemUiSnapshot } {
   const clone = structuredClone(system)
-  const { nodes, rootIds, scenes, bifurcationDiagrams, ui, ...data } = clone
+  const { nodes, rootIds, scenes, bifurcationDiagrams, analysisViewports, ui, ...data } = clone
   return {
     data: data as SystemData,
     ui: {
@@ -53,6 +53,7 @@ export function splitSystem(system: System): { data: SystemData; ui: SystemUiSna
       rootIds,
       scenes,
       bifurcationDiagrams,
+      analysisViewports,
       ui,
     },
   }
@@ -66,6 +67,7 @@ export function mergeSystem(data: SystemData, ui?: SystemUiSnapshot): System {
     rootIds: structuredClone(ui?.rootIds ?? []),
     scenes: structuredClone(ui?.scenes ?? []),
     bifurcationDiagrams: structuredClone(ui?.bifurcationDiagrams ?? []),
+    analysisViewports: structuredClone(ui?.analysisViewports ?? []),
     ui: structuredClone(ui?.ui ?? {}),
     updatedAt,
   } as System
@@ -88,6 +90,7 @@ export function serializeSystemUi(system: System): SystemUiBundle {
     rootIds: structuredClone(system.rootIds),
     scenes: structuredClone(system.scenes),
     bifurcationDiagrams: structuredClone(system.bifurcationDiagrams),
+    analysisViewports: structuredClone(system.analysisViewports),
     ui: structuredClone(system.ui),
   }
   return {

--- a/web/src/system/store.ts
+++ b/web/src/system/store.ts
@@ -84,6 +84,7 @@ export class MemorySystemStore implements SystemStore {
     next.rootIds = [...system.rootIds]
     next.scenes = structuredClone(system.scenes)
     next.bifurcationDiagrams = structuredClone(system.bifurcationDiagrams)
+    next.analysisViewports = structuredClone(system.analysisViewports)
     next.ui = structuredClone(system.ui)
     next.updatedAt = system.updatedAt
     this.systems.set(system.id, next)

--- a/web/src/system/types.ts
+++ b/web/src/system/types.ts
@@ -497,7 +497,7 @@ export interface CovariantLyapunovData {
   vectors: number[][][]
 }
 
-export type NodeKind = 'object' | 'branch' | 'scene' | 'diagram' | 'camera'
+export type NodeKind = 'object' | 'branch' | 'scene' | 'diagram' | 'analysis' | 'camera'
 
 export interface ClvRenderStyle {
   enabled: boolean
@@ -538,7 +538,13 @@ export interface TreeNode {
   id: string
   name: string
   kind: NodeKind
-  objectType?: AnalysisObject['type'] | 'branch' | 'scene' | 'bifurcation' | 'camera'
+  objectType?:
+    | AnalysisObject['type']
+    | 'branch'
+    | 'scene'
+    | 'bifurcation'
+    | 'analysis'
+    | 'camera'
   parentId: string | null
   children: string[]
   visibility: boolean
@@ -570,6 +576,56 @@ export interface Scene {
   selectedNodeIds: string[]
   display: 'all' | 'selection'
 }
+
+export type EventSeriesMode = 'every_iterate' | 'cross_up' | 'cross_down' | 'cross_either'
+
+export interface AnalysisEventSpec {
+  mode: EventSeriesMode
+  expression: string
+  level: number
+}
+
+export type AnalysisAxisSpec =
+  | {
+      kind: 'observable'
+      expression: string
+      label?: string | null
+      hitOffset: -1 | 0 | 1
+    }
+  | {
+      kind: 'hit_index'
+      label?: string | null
+    }
+  | {
+      kind: 'delta_time'
+      label?: string | null
+    }
+
+export interface AnalysisViewportAdvanced {
+  skipHits: number
+  hitStride: number
+  maxHits: number
+  connectPoints: boolean
+}
+
+export interface ReturnMapViewport {
+  id: string
+  name: string
+  kind: 'return_map'
+  axisRanges: AxisRanges
+  viewRevision: number
+  sourceNodeIds: string[]
+  display: 'all' | 'selection'
+  event: AnalysisEventSpec
+  axes: {
+    x: AnalysisAxisSpec
+    y: AnalysisAxisSpec
+    z?: AnalysisAxisSpec | null
+  }
+  advanced: AnalysisViewportAdvanced
+}
+
+export type AnalysisViewport = ReturnMapViewport
 
 export interface BifurcationDiagram {
   id: string
@@ -637,6 +693,7 @@ export interface System {
   branches: Record<string, ContinuationObject>
   scenes: Scene[]
   bifurcationDiagrams: BifurcationDiagram[]
+  analysisViewports: AnalysisViewport[]
   ui: SystemUiState
   updatedAt: string
 }
@@ -658,6 +715,7 @@ export interface SystemUiSnapshot {
   rootIds: string[]
   scenes: Scene[]
   bifurcationDiagrams: BifurcationDiagram[]
+  analysisViewports: AnalysisViewport[]
   ui: SystemUiState
 }
 

--- a/web/src/system/types.ts
+++ b/web/src/system/types.ts
@@ -581,7 +581,7 @@ export type EventSeriesMode = 'every_iterate' | 'cross_up' | 'cross_down' | 'cro
 
 export interface AnalysisEventSpec {
   mode: EventSeriesMode
-  expression: string
+  source: IsoclineSource
   level: number
 }
 
@@ -590,7 +590,7 @@ export type AnalysisAxisSpec =
       kind: 'observable'
       expression: string
       label?: string | null
-      hitOffset: -1 | 0 | 1
+      hitOffset: number
     }
   | {
       kind: 'hit_index'
@@ -599,6 +599,7 @@ export type AnalysisAxisSpec =
   | {
       kind: 'delta_time'
       label?: string | null
+      hitOffset: number
     }
 
 export interface AnalysisViewportAdvanced {

--- a/web/src/ui/AnalysisViewportInspector.test.tsx
+++ b/web/src/ui/AnalysisViewportInspector.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { addAnalysisViewport, createSystem, updateAnalysisViewport } from '../system/model'
+import { AnalysisViewportInspector } from './AnalysisViewportInspector'
+
+function renderInspector(
+  onValidateAnalysisExpression = vi.fn(() => Promise.resolve())
+) {
+  const base = createSystem({
+    name: 'Lorenz',
+    config: {
+      name: 'Lorenz',
+      equations: ['sigma * (y - x)', 'x * (rho - z) - y', 'x * y - beta * z'],
+      params: [10, 28, 8 / 3],
+      paramNames: ['sigma', 'rho', 'beta'],
+      varNames: ['x', 'y', 'z'],
+      solver: 'rk4',
+      type: 'flow',
+    },
+  })
+  const added = addAnalysisViewport(base, 'Event_Map_1')
+
+  function Wrapper() {
+    const [state, setState] = useState(added.system)
+    const viewport = state.analysisViewports.find((entry) => entry.id === added.nodeId)
+    if (!viewport) throw new Error('Missing analysis viewport')
+    return (
+      <AnalysisViewportInspector
+        system={state}
+        viewport={viewport}
+        onUpdateAnalysisViewport={(id, update) => {
+          setState((prev) => updateAnalysisViewport(prev, id, update))
+        }}
+        onValidateAnalysisExpression={onValidateAnalysisExpression}
+      />
+    )
+  }
+
+  render(<Wrapper />)
+  return { onValidateAnalysisExpression }
+}
+
+describe('AnalysisViewportInspector', () => {
+  it('keeps blank custom event expressions blank and shows local validation errors', async () => {
+    const onValidateAnalysisExpression = vi.fn(
+      async ({ expression, role }: { expression: string; role: 'event' | 'observable' }) => {
+        if (role === 'event' && expression === 'xyy') {
+          throw new Error('Event expression error: Unknown variable or parameter: xyy')
+        }
+      }
+    )
+    renderInspector(onValidateAnalysisExpression)
+
+    const input = screen.getByTestId('analysis-event-expression') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '' } })
+    expect(input.value).toBe('')
+    await waitFor(() => {
+      expect(screen.getByTestId('analysis-event-expression-error')).toHaveTextContent(
+        'Expression is required.'
+      )
+    })
+
+    fireEvent.change(input, { target: { value: 'xyy' } })
+    expect(input.value).toBe('xyy')
+    await waitFor(() => {
+      expect(screen.getByTestId('analysis-event-expression-error')).toHaveTextContent(
+        'Unknown variable or parameter: xyy'
+      )
+    })
+  })
+
+  it('supports derived event sources and arbitrary delta-t hit offsets', async () => {
+    renderInspector()
+
+    fireEvent.change(screen.getByTestId('analysis-event-source-kind'), {
+      target: { value: 'flow_derivative' },
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('analysis-event-resolved-expression')).toHaveTextContent(
+        'sigma * (y - x)'
+      )
+    })
+
+    const axisSelectors = screen.getAllByLabelText('Axis value') as HTMLSelectElement[]
+    fireEvent.change(axisSelectors[0], { target: { value: 'delta_time' } })
+
+    const offsetInput = await screen.findByTestId('analysis-axis-hit-offset-x')
+    fireEvent.change(offsetInput, { target: { value: '3' } })
+
+    expect((offsetInput as HTMLInputElement).value).toBe('3')
+    expect(screen.getByText('Using hit n+3.')).toBeInTheDocument()
+  })
+})

--- a/web/src/ui/AnalysisViewportInspector.tsx
+++ b/web/src/ui/AnalysisViewportInspector.tsx
@@ -1,8 +1,12 @@
-import { useMemo, useState } from 'react'
-import type { AnalysisAxisSpec, AnalysisViewport, System } from '../system/types'
+import { useEffect, useMemo, useState } from 'react'
+import type { AnalysisAxisSpec, AnalysisViewport, System, SystemConfig } from '../system/types'
 import {
   collectAnalysisSourceEntries,
+  formatAnalysisHitOffset,
+  normalizeAnalysisExpressionError,
   resolveAnalysisAxisLabel,
+  resolveAnalysisEventExpression,
+  resolveAnalysisSourceExpression,
 } from '../analysis/analysisViewportUtils'
 
 type AnalysisViewportInspectorProps = {
@@ -12,24 +16,31 @@ type AnalysisViewportInspectorProps = {
     id: string,
     update: Partial<Omit<AnalysisViewport, 'id' | 'name'>>
   ) => void
+  onValidateAnalysisExpression?: (
+    request: {
+      system: SystemConfig
+      expression: string
+      role: 'event' | 'observable'
+    },
+    opts?: { signal?: AbortSignal }
+  ) => Promise<void>
 }
 
-function defaultObservableAxis(system: System, hitOffset: -1 | 0 | 1): AnalysisAxisSpec {
+type AxisKey = 'x' | 'y' | 'z'
+type AxisErrors = Record<AxisKey, string | null>
+
+function defaultObservableAxis(system: System, hitOffset: number): AnalysisAxisSpec {
   const expression = system.config.varNames[0] ?? system.config.paramNames[0] ?? 'x'
-  return {
-    kind: 'observable',
-    expression,
-    hitOffset,
-    label: null,
-  }
+  return { kind: 'observable', expression, hitOffset, label: null }
 }
 
 function axisKindValue(axis: AnalysisAxisSpec | null | undefined): string {
-  if (!axis) return 'none'
-  return axis.kind
+  return axis?.kind ?? 'none'
 }
 
-function eventModeOptions(system: System): Array<{ value: AnalysisViewport['event']['mode']; label: string }> {
+function eventModeOptions(
+  system: System
+): Array<{ value: AnalysisViewport['event']['mode']; label: string }> {
   const options: Array<{ value: AnalysisViewport['event']['mode']; label: string }> = [
     { value: 'cross_up', label: 'Crossing up' },
     { value: 'cross_down', label: 'Crossing down' },
@@ -41,12 +52,24 @@ function eventModeOptions(system: System): Array<{ value: AnalysisViewport['even
   return options
 }
 
+function primaryVariable(system: System): string {
+  return system.config.varNames[0] ?? ''
+}
+
+function parseInteger(value: string, fallback = 0): number {
+  const next = Number(value)
+  return Number.isFinite(next) ? Math.trunc(next) : fallback
+}
+
 export function AnalysisViewportInspector({
   system,
   viewport,
   onUpdateAnalysisViewport,
+  onValidateAnalysisExpression,
 }: AnalysisViewportInspectorProps) {
   const [sourceSearch, setSourceSearch] = useState('')
+  const [eventError, setEventError] = useState<string | null>(null)
+  const [axisErrors, setAxisErrors] = useState<AxisErrors>({ x: null, y: null, z: null })
   const sourceEntries = useMemo(() => collectAnalysisSourceEntries(system), [system])
   const selectedSourceSet = useMemo(
     () => new Set(viewport.sourceNodeIds),
@@ -66,38 +89,110 @@ export function AnalysisViewportInspector({
     () => sourceEntries.filter((entry) => selectedSourceSet.has(entry.id)),
     [selectedSourceSet, sourceEntries]
   )
+  const eventExpression = useMemo(
+    () => resolveAnalysisEventExpression(system.config, viewport.event),
+    [system.config, viewport.event]
+  )
+  const eventSourceKind = viewport.event.source.kind
+  const eventSourceVariable = useMemo(() => {
+    if (viewport.event.source.kind === 'custom') return primaryVariable(system)
+    return system.config.varNames.includes(viewport.event.source.variableName)
+      ? viewport.event.source.variableName
+      : primaryVariable(system)
+  }, [system, viewport.event.source])
+  const resolvedSourceExpression = useMemo(
+    () => resolveAnalysisSourceExpression(system.config, viewport.event.source),
+    [system.config, viewport.event.source]
+  )
 
-  const updateAxes = (update: Partial<AnalysisViewport['axes']>) => {
+  useEffect(() => {
+    const controller = new AbortController()
+    const timer = window.setTimeout(() => {
+      void (async () => {
+        let nextEventError: string | null = null
+        const nextAxisErrors: AxisErrors = { x: null, y: null, z: null }
+
+        if (viewport.event.mode !== 'every_iterate') {
+          if (eventExpression.trim().length === 0) {
+            nextEventError = 'Expression is required.'
+          } else if (onValidateAnalysisExpression) {
+            try {
+              await onValidateAnalysisExpression(
+                { system: system.config, expression: eventExpression, role: 'event' },
+                { signal: controller.signal }
+              )
+            } catch (error) {
+              if (!(error instanceof Error && error.name === 'AbortError')) {
+                nextEventError = normalizeAnalysisExpressionError(
+                  error instanceof Error ? error.message : String(error)
+                )
+              }
+            }
+          }
+        }
+
+        const axes: Array<[AxisKey, AnalysisAxisSpec | null | undefined]> = [
+          ['x', viewport.axes.x],
+          ['y', viewport.axes.y],
+          ['z', viewport.axes.z],
+        ]
+        for (const [key, axis] of axes) {
+          if (axis?.kind !== 'observable') continue
+          if (axis.expression.trim().length === 0) {
+            nextAxisErrors[key] = 'Expression is required.'
+            continue
+          }
+          if (!onValidateAnalysisExpression) continue
+          try {
+            await onValidateAnalysisExpression(
+              { system: system.config, expression: axis.expression, role: 'observable' },
+              { signal: controller.signal }
+            )
+          } catch (error) {
+            if (!(error instanceof Error && error.name === 'AbortError')) {
+              nextAxisErrors[key] = normalizeAnalysisExpressionError(
+                error instanceof Error ? error.message : String(error)
+              )
+            }
+          }
+        }
+
+        if (!controller.signal.aborted) {
+          setEventError(nextEventError)
+          setAxisErrors(nextAxisErrors)
+        }
+      })()
+    }, 150)
+
+    return () => {
+      controller.abort()
+      window.clearTimeout(timer)
+    }
+  }, [eventExpression, onValidateAnalysisExpression, system.config, viewport.axes, viewport.event])
+
+  const updateAxis = (key: AxisKey, nextAxis: AnalysisAxisSpec | null) => {
     onUpdateAnalysisViewport(viewport.id, {
       axes: {
         ...viewport.axes,
-        ...update,
+        [key]: nextAxis,
       },
     })
   }
 
-  const updateAxis = (
-    key: 'x' | 'y' | 'z',
-    nextAxis: AnalysisAxisSpec | null
-  ) => {
-    updateAxes({ [key]: nextAxis } as Partial<AnalysisViewport['axes']>)
-  }
-
   const renderAxisEditor = (
-    key: 'x' | 'y' | 'z',
+    key: AxisKey,
     title: string,
     axis: AnalysisAxisSpec | null,
     options?: { allowNone?: boolean }
   ) => {
     const allowNone = options?.allowNone ?? false
-    const kind = axisKindValue(axis)
     return (
       <div className="inspector-subsection" key={`analysis-axis-${key}`}>
         <h4 className="inspector-subheading">{title}</h4>
         <label>
           Axis value
           <select
-            value={kind}
+            value={axisKindValue(axis)}
             onChange={(event) => {
               const nextKind = event.target.value
               if (nextKind === 'none') {
@@ -109,12 +204,16 @@ export function AnalysisViewportInspector({
                 return
               }
               if (nextKind === 'delta_time') {
-                updateAxis(key, { kind: 'delta_time', label: axis?.label ?? null })
+                updateAxis(key, {
+                  kind: 'delta_time',
+                  hitOffset: axis?.kind === 'delta_time' ? axis.hitOffset : 0,
+                  label: axis?.label ?? null,
+                })
                 return
               }
               updateAxis(
                 key,
-                axis && axis.kind === 'observable'
+                axis?.kind === 'observable'
                   ? axis
                   : defaultObservableAxis(system, key === 'y' ? 1 : 0)
               )
@@ -143,30 +242,40 @@ export function AnalysisViewportInspector({
                   <input
                     value={axis.expression}
                     onChange={(event) =>
-                      updateAxis(key, {
-                        ...axis,
-                        expression: event.target.value,
-                      })
+                      updateAxis(key, { ...axis, expression: event.target.value })
                     }
                     placeholder="State or parameter expression"
+                    data-testid={`analysis-axis-expression-${key}`}
                   />
                 </label>
+                {axisErrors[key] ? (
+                  <div
+                    className="field-error"
+                    data-testid={`analysis-axis-expression-error-${key}`}
+                  >
+                    {axisErrors[key]}
+                  </div>
+                ) : null}
+              </>
+            ) : null}
+            {axis.kind === 'observable' || axis.kind === 'delta_time' ? (
+              <>
                 <label>
-                  Sampled hit
-                  <select
+                  Hit offset
+                  <input
+                    type="number"
+                    step={1}
                     value={axis.hitOffset}
                     onChange={(event) =>
                       updateAxis(key, {
                         ...axis,
-                        hitOffset: Number(event.target.value) as -1 | 0 | 1,
+                        hitOffset: parseInteger(event.target.value),
                       })
                     }
-                  >
-                    <option value={-1}>n-1</option>
-                    <option value={0}>n</option>
-                    <option value={1}>n+1</option>
-                  </select>
+                    data-testid={`analysis-axis-hit-offset-${key}`}
+                  />
                 </label>
+                <p className="empty-state">Using hit {formatAnalysisHitOffset(axis.hitOffset)}.</p>
               </>
             ) : null}
           </>
@@ -177,7 +286,7 @@ export function AnalysisViewportInspector({
 
   return (
     <div className="inspector-section">
-      <h3>Return / Event Map</h3>
+      <h3>Event Map</h3>
       <div className="inspector-subsection">
         <h4 className="inspector-subheading">Sources</h4>
         <label>
@@ -293,40 +402,122 @@ export function AnalysisViewportInspector({
             ))}
           </select>
         </label>
-        <label>
-          Event expression
-          <input
-            value={viewport.event.expression}
-            onChange={(event) =>
-              onUpdateAnalysisViewport(viewport.id, {
-                event: {
-                  ...viewport.event,
-                  expression: event.target.value,
-                },
-              })
-            }
-            placeholder="State or parameter expression"
-            data-testid="analysis-event-expression"
-          />
-        </label>
-        <label>
-          Event level
-          <input
-            type="number"
-            value={viewport.event.level}
-            onChange={(event) => {
-              const value = Number(event.target.value)
-              onUpdateAnalysisViewport(viewport.id, {
-                event: {
-                  ...viewport.event,
-                  level: Number.isFinite(value) ? value : 0,
-                },
-              })
-            }}
-            step="any"
-            data-testid="analysis-event-level"
-          />
-        </label>
+        {viewport.event.mode === 'every_iterate' ? (
+          <p className="empty-state">
+            Every iterate uses each landing iterate directly. Event expression and level are ignored
+            in this mode.
+          </p>
+        ) : (
+          <>
+            <label>
+              Source
+              <select
+                value={eventSourceKind}
+                onChange={(event) => {
+                  const nextKind = event.target.value as
+                    | 'custom'
+                    | 'flow_derivative'
+                    | 'map_increment'
+                  if (nextKind === 'custom') {
+                    onUpdateAnalysisViewport(viewport.id, {
+                      event: {
+                        ...viewport.event,
+                        source:
+                          viewport.event.source.kind === 'custom'
+                            ? viewport.event.source
+                            : { kind: 'custom', expression: resolvedSourceExpression },
+                      },
+                    })
+                    return
+                  }
+                  onUpdateAnalysisViewport(viewport.id, {
+                    event: {
+                      ...viewport.event,
+                      source: { kind: nextKind, variableName: eventSourceVariable },
+                    },
+                  })
+                }}
+                data-testid="analysis-event-source-kind"
+              >
+                <option value="custom">Custom expression</option>
+                {system.config.type === 'map' ? (
+                  <option value="map_increment">Map increment (x_n+1 - x_n)</option>
+                ) : (
+                  <option value="flow_derivative">Time derivative (dx/dt)</option>
+                )}
+              </select>
+            </label>
+            {eventSourceKind === 'custom' ? (
+              <label>
+                Expression
+                <input
+                  value={viewport.event.source.kind === 'custom' ? viewport.event.source.expression : ''}
+                  onChange={(event) =>
+                    onUpdateAnalysisViewport(viewport.id, {
+                      event: {
+                        ...viewport.event,
+                        source: { kind: 'custom', expression: event.target.value },
+                      },
+                    })
+                  }
+                  placeholder="State or parameter expression"
+                  data-testid="analysis-event-expression"
+                />
+              </label>
+            ) : (
+              <label>
+                Variable
+                <select
+                  value={eventSourceVariable}
+                  onChange={(event) =>
+                    onUpdateAnalysisViewport(viewport.id, {
+                      event: {
+                        ...viewport.event,
+                        source: {
+                          kind: eventSourceKind as 'flow_derivative' | 'map_increment',
+                          variableName: event.target.value,
+                        },
+                      },
+                    })
+                  }
+                  data-testid="analysis-event-source-variable"
+                >
+                  {system.config.varNames.map((name) => (
+                    <option key={`analysis-event-var-${name}`} value={name}>
+                      {name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+            {eventError ? (
+              <div className="field-error" data-testid="analysis-event-expression-error">
+                {eventError}
+              </div>
+            ) : null}
+            <label>
+              Event level
+              <input
+                type="number"
+                value={viewport.event.level}
+                onChange={(event) => {
+                  const value = Number(event.target.value)
+                  onUpdateAnalysisViewport(viewport.id, {
+                    event: {
+                      ...viewport.event,
+                      level: Number.isFinite(value) ? value : 0,
+                    },
+                  })
+                }}
+                step="any"
+                data-testid="analysis-event-level"
+              />
+            </label>
+            <p className="empty-state" data-testid="analysis-event-resolved-expression">
+              f(x, p) = {eventExpression || '∅'}
+            </p>
+          </>
+        )}
       </div>
 
       <div className="inspector-subsection">

--- a/web/src/ui/AnalysisViewportInspector.tsx
+++ b/web/src/ui/AnalysisViewportInspector.tsx
@@ -1,0 +1,413 @@
+import { useMemo, useState } from 'react'
+import type { AnalysisAxisSpec, AnalysisViewport, System } from '../system/types'
+import {
+  collectAnalysisSourceEntries,
+  resolveAnalysisAxisLabel,
+} from '../analysis/analysisViewportUtils'
+
+type AnalysisViewportInspectorProps = {
+  system: System
+  viewport: AnalysisViewport
+  onUpdateAnalysisViewport: (
+    id: string,
+    update: Partial<Omit<AnalysisViewport, 'id' | 'name'>>
+  ) => void
+}
+
+function defaultObservableAxis(system: System, hitOffset: -1 | 0 | 1): AnalysisAxisSpec {
+  const expression = system.config.varNames[0] ?? system.config.paramNames[0] ?? 'x'
+  return {
+    kind: 'observable',
+    expression,
+    hitOffset,
+    label: null,
+  }
+}
+
+function axisKindValue(axis: AnalysisAxisSpec | null | undefined): string {
+  if (!axis) return 'none'
+  return axis.kind
+}
+
+function eventModeOptions(system: System): Array<{ value: AnalysisViewport['event']['mode']; label: string }> {
+  const options: Array<{ value: AnalysisViewport['event']['mode']; label: string }> = [
+    { value: 'cross_up', label: 'Crossing up' },
+    { value: 'cross_down', label: 'Crossing down' },
+    { value: 'cross_either', label: 'Crossing either way' },
+  ]
+  if (system.config.type === 'map') {
+    options.unshift({ value: 'every_iterate', label: 'Every iterate' })
+  }
+  return options
+}
+
+export function AnalysisViewportInspector({
+  system,
+  viewport,
+  onUpdateAnalysisViewport,
+}: AnalysisViewportInspectorProps) {
+  const [sourceSearch, setSourceSearch] = useState('')
+  const sourceEntries = useMemo(() => collectAnalysisSourceEntries(system), [system])
+  const selectedSourceSet = useMemo(
+    () => new Set(viewport.sourceNodeIds),
+    [viewport.sourceNodeIds]
+  )
+  const filteredEntries = useMemo(() => {
+    const query = sourceSearch.trim().toLowerCase()
+    if (!query) return sourceEntries
+    return sourceEntries.filter((entry) => {
+      return (
+        entry.name.toLowerCase().includes(query) ||
+        entry.typeLabel.toLowerCase().includes(query)
+      )
+    })
+  }, [sourceEntries, sourceSearch])
+  const selectedEntries = useMemo(
+    () => sourceEntries.filter((entry) => selectedSourceSet.has(entry.id)),
+    [selectedSourceSet, sourceEntries]
+  )
+
+  const updateAxes = (update: Partial<AnalysisViewport['axes']>) => {
+    onUpdateAnalysisViewport(viewport.id, {
+      axes: {
+        ...viewport.axes,
+        ...update,
+      },
+    })
+  }
+
+  const updateAxis = (
+    key: 'x' | 'y' | 'z',
+    nextAxis: AnalysisAxisSpec | null
+  ) => {
+    updateAxes({ [key]: nextAxis } as Partial<AnalysisViewport['axes']>)
+  }
+
+  const renderAxisEditor = (
+    key: 'x' | 'y' | 'z',
+    title: string,
+    axis: AnalysisAxisSpec | null,
+    options?: { allowNone?: boolean }
+  ) => {
+    const allowNone = options?.allowNone ?? false
+    const kind = axisKindValue(axis)
+    return (
+      <div className="inspector-subsection" key={`analysis-axis-${key}`}>
+        <h4 className="inspector-subheading">{title}</h4>
+        <label>
+          Axis value
+          <select
+            value={kind}
+            onChange={(event) => {
+              const nextKind = event.target.value
+              if (nextKind === 'none') {
+                updateAxis(key, null)
+                return
+              }
+              if (nextKind === 'hit_index') {
+                updateAxis(key, { kind: 'hit_index', label: axis?.label ?? null })
+                return
+              }
+              if (nextKind === 'delta_time') {
+                updateAxis(key, { kind: 'delta_time', label: axis?.label ?? null })
+                return
+              }
+              updateAxis(
+                key,
+                axis && axis.kind === 'observable'
+                  ? axis
+                  : defaultObservableAxis(system, key === 'y' ? 1 : 0)
+              )
+            }}
+          >
+            {allowNone ? <option value="none">Disabled</option> : null}
+            <option value="observable">Observable expression</option>
+            <option value="hit_index">Hit index</option>
+            <option value="delta_time">Delta t</option>
+          </select>
+        </label>
+        {axis ? (
+          <>
+            <label>
+              Label
+              <input
+                value={axis.label ?? ''}
+                onChange={(event) => updateAxis(key, { ...axis, label: event.target.value })}
+                placeholder={resolveAnalysisAxisLabel(axis)}
+              />
+            </label>
+            {axis.kind === 'observable' ? (
+              <>
+                <label>
+                  Expression
+                  <input
+                    value={axis.expression}
+                    onChange={(event) =>
+                      updateAxis(key, {
+                        ...axis,
+                        expression: event.target.value,
+                      })
+                    }
+                    placeholder="State or parameter expression"
+                  />
+                </label>
+                <label>
+                  Sampled hit
+                  <select
+                    value={axis.hitOffset}
+                    onChange={(event) =>
+                      updateAxis(key, {
+                        ...axis,
+                        hitOffset: Number(event.target.value) as -1 | 0 | 1,
+                      })
+                    }
+                  >
+                    <option value={-1}>n-1</option>
+                    <option value={0}>n</option>
+                    <option value={1}>n+1</option>
+                  </select>
+                </label>
+              </>
+            ) : null}
+          </>
+        ) : null}
+      </div>
+    )
+  }
+
+  return (
+    <div className="inspector-section">
+      <h3>Return / Event Map</h3>
+      <div className="inspector-subsection">
+        <h4 className="inspector-subheading">Sources</h4>
+        <label>
+          Fallback display
+          <select
+            value={viewport.display}
+            onChange={(event) =>
+              onUpdateAnalysisViewport(viewport.id, {
+                display: event.target.value as AnalysisViewport['display'],
+              })
+            }
+            data-testid="analysis-display"
+          >
+            <option value="all">All visible compatible sources</option>
+            <option value="selection">Selected compatible source</option>
+          </select>
+        </label>
+        <p className="empty-state">
+          Explicitly selected sources override the fallback mode. Axis expressions can use state
+          variables and system parameters.
+        </p>
+        <label>
+          Search compatible sources
+          <input
+            value={sourceSearch}
+            onChange={(event) => setSourceSearch(event.target.value)}
+            placeholder="Type to filter…"
+          />
+        </label>
+        {selectedEntries.length > 0 ? (
+          <div className="scene-object-selected">
+            {selectedEntries.map((entry) => (
+              <div className="scene-object-selected__row" key={`analysis-sel-${entry.id}`}>
+                <div className="scene-object-selected__info">
+                  <span>{entry.name}</span>
+                  <span className="scene-object-selected__meta">
+                    {entry.typeLabel}
+                    {entry.visible ? '' : ' · hidden'}
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  className="scene-object-selected__remove"
+                  onClick={() => {
+                    onUpdateAnalysisViewport(viewport.id, {
+                      sourceNodeIds: viewport.sourceNodeIds.filter((id) => id !== entry.id),
+                    })
+                  }}
+                  aria-label={`Remove ${entry.name} from analysis viewport`}
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="empty-state">
+            {viewport.display === 'selection'
+              ? 'No explicit sources selected. The current compatible selection will be used.'
+              : 'No explicit sources selected. All visible compatible sources will be used.'}
+          </p>
+        )}
+        {filteredEntries.length > 0 ? (
+          <div className="scene-object-list">
+            {filteredEntries.map((entry) => {
+              const checked = selectedSourceSet.has(entry.id)
+              return (
+                <label key={`analysis-entry-${entry.id}`} className="scene-object-row">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => {
+                      const next = checked
+                        ? viewport.sourceNodeIds.filter((id) => id !== entry.id)
+                        : [...viewport.sourceNodeIds, entry.id]
+                      onUpdateAnalysisViewport(viewport.id, { sourceNodeIds: next })
+                    }}
+                  />
+                  <span className="scene-object-row__name">{entry.name}</span>
+                  <span className="scene-object-row__meta">
+                    {entry.typeLabel}
+                    {entry.visible ? '' : ' · hidden'}
+                  </span>
+                </label>
+              )
+            })}
+          </div>
+        ) : (
+          <p className="empty-state">No compatible sources match this search.</p>
+        )}
+      </div>
+
+      <div className="inspector-subsection">
+        <h4 className="inspector-subheading">Event</h4>
+        <label>
+          Event mode
+          <select
+            value={viewport.event.mode}
+            onChange={(event) =>
+              onUpdateAnalysisViewport(viewport.id, {
+                event: {
+                  ...viewport.event,
+                  mode: event.target.value as AnalysisViewport['event']['mode'],
+                },
+              })
+            }
+            data-testid="analysis-event-mode"
+          >
+            {eventModeOptions(system).map((option) => (
+              <option key={`analysis-mode-${option.value}`} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Event expression
+          <input
+            value={viewport.event.expression}
+            onChange={(event) =>
+              onUpdateAnalysisViewport(viewport.id, {
+                event: {
+                  ...viewport.event,
+                  expression: event.target.value,
+                },
+              })
+            }
+            placeholder="State or parameter expression"
+            data-testid="analysis-event-expression"
+          />
+        </label>
+        <label>
+          Event level
+          <input
+            type="number"
+            value={viewport.event.level}
+            onChange={(event) => {
+              const value = Number(event.target.value)
+              onUpdateAnalysisViewport(viewport.id, {
+                event: {
+                  ...viewport.event,
+                  level: Number.isFinite(value) ? value : 0,
+                },
+              })
+            }}
+            step="any"
+            data-testid="analysis-event-level"
+          />
+        </label>
+      </div>
+
+      <div className="inspector-subsection">
+        <h4 className="inspector-subheading">Axes</h4>
+        {renderAxisEditor('x', 'X axis', viewport.axes.x)}
+        {renderAxisEditor('y', 'Y axis', viewport.axes.y)}
+        {renderAxisEditor('z', 'Z axis', viewport.axes.z ?? null, { allowNone: true })}
+      </div>
+
+      <div className="inspector-subsection">
+        <h4 className="inspector-subheading">Advanced</h4>
+        <label>
+          Skip hits
+          <input
+            type="number"
+            min={0}
+            step={1}
+            value={viewport.advanced.skipHits}
+            onChange={(event) => {
+              const value = Number(event.target.value)
+              onUpdateAnalysisViewport(viewport.id, {
+                advanced: {
+                  ...viewport.advanced,
+                  skipHits: Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0,
+                },
+              })
+            }}
+          />
+        </label>
+        <label>
+          Hit stride
+          <input
+            type="number"
+            min={1}
+            step={1}
+            value={viewport.advanced.hitStride}
+            onChange={(event) => {
+              const value = Number(event.target.value)
+              onUpdateAnalysisViewport(viewport.id, {
+                advanced: {
+                  ...viewport.advanced,
+                  hitStride: Number.isFinite(value) ? Math.max(1, Math.trunc(value)) : 1,
+                },
+              })
+            }}
+          />
+        </label>
+        <label>
+          Max hits
+          <input
+            type="number"
+            min={1}
+            step={1}
+            value={viewport.advanced.maxHits}
+            onChange={(event) => {
+              const value = Number(event.target.value)
+              onUpdateAnalysisViewport(viewport.id, {
+                advanced: {
+                  ...viewport.advanced,
+                  maxHits: Number.isFinite(value) ? Math.max(1, Math.trunc(value)) : 1,
+                },
+              })
+            }}
+          />
+        </label>
+        <label className="checkbox-row">
+          <input
+            type="checkbox"
+            checked={viewport.advanced.connectPoints}
+            onChange={(event) =>
+              onUpdateAnalysisViewport(viewport.id, {
+                advanced: {
+                  ...viewport.advanced,
+                  connectPoints: event.target.checked,
+                },
+              })
+            }
+          />
+          Connect plotted hits
+        </label>
+      </div>
+    </div>
+  )
+}

--- a/web/src/ui/InspectorDetailsPanel.tsx
+++ b/web/src/ui/InspectorDetailsPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import type { Data, Layout } from 'plotly.js'
 import type {
+  AnalysisViewport,
   BifurcationAxis,
   BifurcationDiagram,
   ClvRenderStyle,
@@ -97,6 +98,7 @@ import {
   cycleManifoldFloquetEligibility,
   normalizeFloquetMultipliersForRendering,
 } from '../system/floquetModes'
+import { AnalysisViewportInspector } from './AnalysisViewportInspector'
 
 type InspectorDetailsPanelProps = {
   system: System
@@ -126,6 +128,10 @@ type InspectorDetailsPanelProps = {
     opts?: { signal?: AbortSignal; silent?: boolean }
   ) => Promise<unknown>
   onUpdateScene: (id: string, update: Partial<Omit<Scene, 'id' | 'name'>>) => void
+  onUpdateAnalysisViewport?: (
+    id: string,
+    update: Partial<Omit<AnalysisViewport, 'id' | 'name'>>
+  ) => void
   onUpdateBifurcationDiagram: (
     id: string,
     update: Partial<Omit<BifurcationDiagram, 'id' | 'name'>>
@@ -1852,6 +1858,7 @@ export function InspectorDetailsPanel({
   onUpdateIsoclineObject = () => {},
   onComputeIsocline = async () => null,
   onUpdateScene,
+  onUpdateAnalysisViewport,
   onUpdateBifurcationDiagram,
   onSetLimitCycleRenderTarget,
   onUpdateSystem,
@@ -1943,6 +1950,9 @@ export function InspectorDetailsPanel({
   }, [onRename, selectionNameDraft, selectionNode])
   const scene = selectedNodeId
     ? system.scenes.find((entry) => entry.id === selectedNodeId)
+    : undefined
+  const analysis = selectedNodeId
+    ? system.analysisViewports.find((entry) => entry.id === selectedNodeId)
     : undefined
   const diagram = selectedNodeId
     ? system.bifurcationDiagrams.find((entry) => entry.id === selectedNodeId)
@@ -10436,6 +10446,14 @@ export function InspectorDetailsPanel({
                 )}
               </div>
             </div>
+          ) : null}
+
+          {analysis ? (
+            <AnalysisViewportInspector
+              system={system}
+              viewport={analysis}
+              onUpdateAnalysisViewport={onUpdateAnalysisViewport ?? (() => undefined)}
+            />
           ) : null}
 
           {diagram ? (

--- a/web/src/ui/InspectorDetailsPanel.tsx
+++ b/web/src/ui/InspectorDetailsPanel.tsx
@@ -132,6 +132,14 @@ type InspectorDetailsPanelProps = {
     id: string,
     update: Partial<Omit<AnalysisViewport, 'id' | 'name'>>
   ) => void
+  onValidateAnalysisExpression?: (
+    request: {
+      system: SystemConfig
+      expression: string
+      role: 'event' | 'observable'
+    },
+    opts?: { signal?: AbortSignal }
+  ) => Promise<void>
   onUpdateBifurcationDiagram: (
     id: string,
     update: Partial<Omit<BifurcationDiagram, 'id' | 'name'>>
@@ -1859,6 +1867,7 @@ export function InspectorDetailsPanel({
   onComputeIsocline = async () => null,
   onUpdateScene,
   onUpdateAnalysisViewport,
+  onValidateAnalysisExpression,
   onUpdateBifurcationDiagram,
   onSetLimitCycleRenderTarget,
   onUpdateSystem,
@@ -10453,6 +10462,7 @@ export function InspectorDetailsPanel({
               system={system}
               viewport={analysis}
               onUpdateAnalysisViewport={onUpdateAnalysisViewport ?? (() => undefined)}
+              onValidateAnalysisExpression={onValidateAnalysisExpression}
             />
           ) : null}
 

--- a/web/src/ui/InspectorPanel.tsx
+++ b/web/src/ui/InspectorPanel.tsx
@@ -1,5 +1,6 @@
 import { InspectorDetailsPanel } from './InspectorDetailsPanel'
 import type {
+  AnalysisViewport,
   BifurcationDiagram,
   IsoclineObject,
   LimitCycleRenderTarget,
@@ -67,6 +68,10 @@ type InspectorPanelProps = {
     opts?: { signal?: AbortSignal; silent?: boolean }
   ) => Promise<unknown>
   onUpdateScene: (id: string, update: Partial<Omit<Scene, 'id' | 'name'>>) => void
+  onUpdateAnalysisViewport: (
+    id: string,
+    update: Partial<Omit<AnalysisViewport, 'id' | 'name'>>
+  ) => void
   onUpdateBifurcationDiagram: (
     id: string,
     update: Partial<Omit<BifurcationDiagram, 'id' | 'name'>>
@@ -142,6 +147,7 @@ export function InspectorPanel({
   onUpdateIsoclineObject,
   onComputeIsocline,
   onUpdateScene,
+  onUpdateAnalysisViewport,
   onUpdateBifurcationDiagram,
   onSetLimitCycleRenderTarget,
   onUpdateSystem,
@@ -192,6 +198,7 @@ export function InspectorPanel({
           onUpdateIsoclineObject={onUpdateIsoclineObject}
           onComputeIsocline={onComputeIsocline}
           onUpdateScene={onUpdateScene}
+          onUpdateAnalysisViewport={onUpdateAnalysisViewport}
           onUpdateBifurcationDiagram={onUpdateBifurcationDiagram}
           onSetLimitCycleRenderTarget={onSetLimitCycleRenderTarget}
           onUpdateSystem={onUpdateSystem}

--- a/web/src/ui/InspectorPanel.tsx
+++ b/web/src/ui/InspectorPanel.tsx
@@ -72,6 +72,14 @@ type InspectorPanelProps = {
     id: string,
     update: Partial<Omit<AnalysisViewport, 'id' | 'name'>>
   ) => void
+  onValidateAnalysisExpression?: (
+    request: {
+      system: SystemConfig
+      expression: string
+      role: 'event' | 'observable'
+    },
+    opts?: { signal?: AbortSignal }
+  ) => Promise<void>
   onUpdateBifurcationDiagram: (
     id: string,
     update: Partial<Omit<BifurcationDiagram, 'id' | 'name'>>
@@ -148,6 +156,7 @@ export function InspectorPanel({
   onComputeIsocline,
   onUpdateScene,
   onUpdateAnalysisViewport,
+  onValidateAnalysisExpression,
   onUpdateBifurcationDiagram,
   onSetLimitCycleRenderTarget,
   onUpdateSystem,
@@ -199,6 +208,7 @@ export function InspectorPanel({
           onComputeIsocline={onComputeIsocline}
           onUpdateScene={onUpdateScene}
           onUpdateAnalysisViewport={onUpdateAnalysisViewport}
+          onValidateAnalysisExpression={onValidateAnalysisExpression}
           onUpdateBifurcationDiagram={onUpdateBifurcationDiagram}
           onSetLimitCycleRenderTarget={onSetLimitCycleRenderTarget}
           onUpdateSystem={onUpdateSystem}

--- a/web/src/ui/SystemSettingsDialog.tsx
+++ b/web/src/ui/SystemSettingsDialog.tsx
@@ -64,6 +64,14 @@ type SystemSettingsDialogProps = {
     id: string,
     update: Partial<Omit<AnalysisViewport, 'id' | 'name'>>
   ) => void
+  onValidateAnalysisExpression?: (
+    request: {
+      system: SystemConfig
+      expression: string
+      role: 'event' | 'observable'
+    },
+    opts?: { signal?: AbortSignal }
+  ) => Promise<void>
   onUpdateBifurcationDiagram: (
     id: string,
     update: Partial<Omit<BifurcationDiagram, 'id' | 'name'>>
@@ -140,6 +148,7 @@ export function SystemSettingsDialog({
   onUpdateObjectFrozenVariables,
   onUpdateScene,
   onUpdateAnalysisViewport,
+  onValidateAnalysisExpression,
   onUpdateBifurcationDiagram,
   onSetLimitCycleRenderTarget,
   onUpdateSystem,
@@ -208,6 +217,7 @@ export function SystemSettingsDialog({
             onUpdateObjectFrozenVariables={onUpdateObjectFrozenVariables}
             onUpdateScene={onUpdateScene}
             onUpdateAnalysisViewport={onUpdateAnalysisViewport}
+            onValidateAnalysisExpression={onValidateAnalysisExpression}
             onUpdateBifurcationDiagram={onUpdateBifurcationDiagram}
             onSetLimitCycleRenderTarget={onSetLimitCycleRenderTarget}
             onUpdateSystem={onUpdateSystem}

--- a/web/src/ui/SystemSettingsDialog.tsx
+++ b/web/src/ui/SystemSettingsDialog.tsx
@@ -1,5 +1,6 @@
 import { InspectorDetailsPanel } from './InspectorDetailsPanel'
 import type {
+  AnalysisViewport,
   BifurcationDiagram,
   LimitCycleRenderTarget,
   Scene,
@@ -59,6 +60,10 @@ type SystemSettingsDialogProps = {
     frozenValuesByVarName: Record<string, number>
   ) => void
   onUpdateScene: (id: string, update: Partial<Omit<Scene, 'id' | 'name'>>) => void
+  onUpdateAnalysisViewport?: (
+    id: string,
+    update: Partial<Omit<AnalysisViewport, 'id' | 'name'>>
+  ) => void
   onUpdateBifurcationDiagram: (
     id: string,
     update: Partial<Omit<BifurcationDiagram, 'id' | 'name'>>
@@ -134,6 +139,7 @@ export function SystemSettingsDialog({
   onUpdateObjectParams,
   onUpdateObjectFrozenVariables,
   onUpdateScene,
+  onUpdateAnalysisViewport,
   onUpdateBifurcationDiagram,
   onSetLimitCycleRenderTarget,
   onUpdateSystem,
@@ -201,6 +207,7 @@ export function SystemSettingsDialog({
             onUpdateObjectParams={onUpdateObjectParams}
             onUpdateObjectFrozenVariables={onUpdateObjectFrozenVariables}
             onUpdateScene={onUpdateScene}
+            onUpdateAnalysisViewport={onUpdateAnalysisViewport}
             onUpdateBifurcationDiagram={onUpdateBifurcationDiagram}
             onSetLimitCycleRenderTarget={onSetLimitCycleRenderTarget}
             onUpdateSystem={onUpdateSystem}

--- a/web/src/ui/ViewportPanel.test.tsx
+++ b/web/src/ui/ViewportPanel.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useState } from 'react'
 import userEvent from '@testing-library/user-event'
 import type { Data, Layout } from 'plotly.js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -6,12 +7,14 @@ import { ViewportPanel } from './ViewportPanel'
 import type { ComputeIsoclineResult } from '../compute/ForkCoreClient'
 import {
   addObject,
+  addAnalysisViewport,
   addBranch,
   addBifurcationDiagram,
   addScene,
   updateNodeRender,
   createSystem,
   updateLimitCycleRenderTarget,
+  updateAnalysisViewport,
   updateBifurcationDiagram,
   updateScene,
 } from '../system/model'
@@ -3833,4 +3836,123 @@ describe('ViewportPanel view state wiring', () => {
     )
     expect(cobwebTrace).toBeFalsy()
   })
+
+  it('updates event map traces when source render styles change', async () => {
+    const config: SystemConfig = {
+      name: 'Analysis_Render_System',
+      equations: ['y', '-x'],
+      params: [],
+      paramNames: [],
+      varNames: ['x', 'y'],
+      solver: 'rk4',
+      type: 'flow',
+    }
+    let system = createSystem({ name: 'Analysis_Render_System', config })
+    const analysisResult = addAnalysisViewport(system, 'Event_Map_1')
+    system = analysisResult.system
+    const orbit: OrbitObject = {
+      type: 'orbit',
+      name: 'Orbit_Render_Target',
+      systemName: config.name,
+      data: [
+        [0, 0, 1],
+        [0.1, 1, 0],
+      ],
+      t_start: 0,
+      t_end: 0.1,
+      dt: 0.1,
+    }
+    const orbitResult = addObject(system, orbit)
+    system = orbitResult.system
+    system = updateAnalysisViewport(system, analysisResult.nodeId, {
+      sourceNodeIds: [orbitResult.nodeId],
+      event: {
+        mode: 'cross_up',
+        source: { kind: 'custom', expression: 'x' },
+        level: 0,
+      },
+      axes: {
+        x: { kind: 'observable', expression: 'x', hitOffset: 0, label: 'x@n' },
+        y: { kind: 'hit_index', label: 'n' },
+        z: null,
+      },
+    })
+    system = updateNodeRender(system, orbitResult.nodeId, { pointSize: 5, lineWidth: 2 })
+    const onComputeEventSeriesFromSamples = vi.fn().mockResolvedValue({
+      hits: [
+        {
+          order: 0,
+          sample_index: 1,
+          time: 0.1,
+          state: [1, 0],
+          observable_values: [1],
+        },
+      ],
+    })
+
+    function Wrapper() {
+      const [state, setState] = useState(system)
+      return (
+        <>
+          <ViewportPanel
+            system={state}
+            selectedNodeId={null}
+            theme="light"
+            onSelectViewport={vi.fn()}
+            onSelectObject={vi.fn()}
+            onReorderViewport={vi.fn()}
+            onResizeViewport={vi.fn()}
+            onToggleViewport={vi.fn()}
+            onCreateScene={vi.fn()}
+            onCreateAnalysis={vi.fn()}
+            onCreateBifurcation={vi.fn()}
+            onRenameViewport={vi.fn()}
+            onDeleteViewport={vi.fn()}
+            onComputeEventSeriesFromSamples={onComputeEventSeriesFromSamples}
+          />
+          <button
+            data-testid="update-analysis-render"
+            onClick={() => {
+              setState((prev) =>
+                updateNodeRender(prev, orbitResult.nodeId, { pointSize: 11, lineWidth: 7 })
+              )
+            }}
+          >
+            Update render
+          </button>
+        </>
+      )
+    }
+
+    render(<Wrapper />)
+
+    const latestCallFor = () => {
+      const calls = plotlyCalls.filter(
+        (entry) => entry.plotId === analysisResult.nodeId && entry.data.length > 0
+      )
+      return calls[calls.length - 1]
+    }
+
+    await waitFor(() => {
+      const props = latestCallFor()
+      expect(props).toBeTruthy()
+      const trace = props?.data[0] as
+        | { marker?: { size?: number }; line?: { width?: number } }
+        | undefined
+      expect(trace?.marker?.size).toBe(5)
+      expect(trace?.line?.width).toBe(2)
+    })
+
+    fireEvent.click(screen.getByTestId('update-analysis-render'))
+
+    await waitFor(() => {
+      const props = latestCallFor()
+      const trace = props?.data[0] as
+        | { marker?: { size?: number }; line?: { width?: number } }
+        | undefined
+      expect(trace?.marker?.size).toBe(11)
+      expect(trace?.line?.width).toBe(7)
+    })
+  })
+
 })

--- a/web/src/ui/ViewportPanel.tsx
+++ b/web/src/ui/ViewportPanel.tsx
@@ -6266,7 +6266,7 @@ function ViewportTile({
     sceneTraces,
   ])
 
-  const label = scene ? 'State Space' : analysis ? 'Return / Event Map' : 'Bifurcation Diagram'
+  const label = scene ? 'State Space' : analysis ? 'Event Map' : 'Bifurcation Diagram'
   const viewportTypeClass = diagram
     ? 'viewport-tile--diagram'
     : analysis
@@ -6738,7 +6738,7 @@ export function ViewportPanel({
         }}
         data-testid="viewport-create-analysis"
       >
-        Return / Event Map
+        Event Map
       </button>
       <button
         className="context-menu__item"

--- a/web/src/ui/ViewportPanel.tsx
+++ b/web/src/ui/ViewportPanel.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react'
 import type { Data, Layout } from 'plotly.js'
 import type {
+  AnalysisViewport,
   AxisRange,
   BifurcationAxis,
   BifurcationDiagram,
@@ -29,7 +30,10 @@ import type {
   TreeNode,
 } from '../system/types'
 import type {
+  ComputeEventSeriesFromOrbitRequest,
+  ComputeEventSeriesFromSamplesRequest,
   ComputeIsoclineResult,
+  EventSeriesResult,
   SampleMap1DFunctionRequest,
   SampleMap1DFunctionResult,
 } from '../compute/ForkCoreClient'
@@ -60,6 +64,7 @@ import {
 } from '../system/subsystemGateway'
 import { normalizeFloquetMultipliersForRendering } from '../system/floquetModes'
 import { PlotlyViewport, type PlotlyPointClick } from '../viewports/plotly/PlotlyViewport'
+import { AnalysisViewportPlot } from '../analysis/AnalysisViewportPlot'
 import type { PlotlyRelayoutEvent } from '../viewports/plotly/usePlotViewport'
 import { resolvePlotlyThemeTokens, type PlotlyThemeTokens } from '../viewports/plotly/plotlyTheme'
 import { confirmDelete, getDeleteKindLabel } from './confirmDelete'
@@ -82,10 +87,19 @@ type ViewportPanelProps = {
   onSelectBranchPoint?: (selection: BranchPointSelection) => void
   onSelectOrbitPoint?: (selection: OrbitPointSelection) => void
   onSelectLimitCyclePoint?: (selection: LimitCyclePointSelection) => void
+  onComputeEventSeriesFromOrbit?: (
+    request: ComputeEventSeriesFromOrbitRequest,
+    opts?: { signal?: AbortSignal }
+  ) => Promise<EventSeriesResult>
+  onComputeEventSeriesFromSamples?: (
+    request: ComputeEventSeriesFromSamplesRequest,
+    opts?: { signal?: AbortSignal }
+  ) => Promise<EventSeriesResult>
   onReorderViewport: (nodeId: string, targetId: string) => void
   onResizeViewport: (id: string, height: number) => void
   onToggleViewport: (id: string) => void
   onCreateScene: (targetId?: string | null) => void
+  onCreateAnalysis?: (targetId?: string | null) => void
   onCreateBifurcation: (targetId?: string | null) => void
   onRenameViewport: (id: string, name: string) => void
   onDuplicateViewport?: (id: string) => void | Promise<void>
@@ -106,6 +120,7 @@ type ViewportPanelProps = {
 type ViewportEntry = {
   node: TreeNode
   scene?: Scene
+  analysis?: AnalysisViewport
   diagram?: BifurcationDiagram
 }
 
@@ -127,6 +142,14 @@ type ViewportTileProps = {
   onSelectBranchPoint?: (selection: BranchPointSelection) => void
   onSelectOrbitPoint?: (selection: OrbitPointSelection) => void
   onSelectLimitCyclePoint?: (selection: LimitCyclePointSelection) => void
+  onComputeEventSeriesFromOrbit?: (
+    request: ComputeEventSeriesFromOrbitRequest,
+    opts?: { signal?: AbortSignal }
+  ) => Promise<EventSeriesResult>
+  onComputeEventSeriesFromSamples?: (
+    request: ComputeEventSeriesFromSamplesRequest,
+    opts?: { signal?: AbortSignal }
+    ) => Promise<EventSeriesResult>
   onReorderViewport: (nodeId: string, targetId: string) => void
   onResizeStart: (id: string, event: React.PointerEvent) => void
   onToggleViewport: (id: string) => void
@@ -5941,6 +5964,8 @@ function ViewportTile({
   mapFunctionSamples,
   draggingId,
   dragOverId,
+  onComputeEventSeriesFromOrbit,
+  onComputeEventSeriesFromSamples,
   setDraggingId,
   setDragOverId,
   onSelectViewport,
@@ -5960,7 +5985,7 @@ function ViewportTile({
   plotlyTheme,
   isoclineGeometryCache,
 }: ViewportTileProps) {
-  const { node, scene, diagram } = entry
+  const { node, scene, analysis, diagram } = entry
   const systemId = system.id
   const systemName = system.name
   const systemConfig = system.config
@@ -5970,6 +5995,7 @@ function ViewportTile({
   const systemObjects = system.objects
   const systemBranches = system.branches
   const systemScenes = system.scenes
+  const systemAnalysisViewports = system.analysisViewports
   const systemDiagrams = system.bifurcationDiagrams
   const uiLayout = system.ui.layout
   const uiViewportHeights = system.ui.viewportHeights
@@ -5986,6 +6012,7 @@ function ViewportTile({
       branches: systemBranches,
       scenes: systemScenes,
       bifurcationDiagrams: systemDiagrams,
+      analysisViewports: systemAnalysisViewports,
       ui: {
         selectedNodeId: null,
         layout: uiLayout,
@@ -6006,6 +6033,7 @@ function ViewportTile({
       systemObjects,
       systemRootIds,
       systemScenes,
+      systemAnalysisViewports,
       uiLayout,
       uiViewportHeights,
     ]
@@ -6020,7 +6048,8 @@ function ViewportTile({
       ? selectedNode.id
       : null
   const selectedViewportId =
-    selectedNode && (selectedNode.kind === 'scene' || selectedNode.kind === 'diagram')
+    selectedNode &&
+    (selectedNode.kind === 'scene' || selectedNode.kind === 'diagram' || selectedNode.kind === 'analysis')
       ? selectedNode.id
       : null
   const sceneTraceSelectedNodeId = scene?.display === 'selection' ? selectedPlotNodeId : null
@@ -6142,7 +6171,7 @@ function ViewportTile({
     )
   }, [branchPointSelection, diagram, diagramTraceSelectedNodeId, traceSystem])
 
-  const viewRevision = scene?.viewRevision ?? diagram?.viewRevision ?? 0
+  const viewRevision = scene?.viewRevision ?? analysis?.viewRevision ?? diagram?.viewRevision ?? 0
   const initialView = useMemo(() => {
     if (scene) return buildSceneInitialView(traceSystem, scene)
     if (diagram) return buildDiagramInitialView(diagram)
@@ -6237,8 +6266,12 @@ function ViewportTile({
     sceneTraces,
   ])
 
-  const label = scene ? 'State Space' : 'Bifurcation Diagram'
-  const viewportTypeClass = diagram ? 'viewport-tile--diagram' : ''
+  const label = scene ? 'State Space' : analysis ? 'Return / Event Map' : 'Bifurcation Diagram'
+  const viewportTypeClass = diagram
+    ? 'viewport-tile--diagram'
+    : analysis
+      ? 'viewport-tile--analysis'
+      : ''
 
   return (
     <section
@@ -6327,17 +6360,29 @@ function ViewportTile({
       {isCollapsed ? null : (
         <>
           <div className="viewport-tile__body">
-            <PlotlyViewport
-              plotId={node.id}
-              data={data}
-              layout={layout}
-              viewRevision={viewRevision}
-              persistView
-              initialView={initialView}
-              testId={`plotly-viewport-${node.id}`}
-              onPointClick={scene || diagram ? handlePointClick : undefined}
-              onResize={scene ? handleResize : undefined}
-            />
+            {analysis ? (
+              <AnalysisViewportPlot
+                system={system}
+                viewport={analysis}
+                selectedNodeId={selectedNodeId}
+                plotlyTheme={plotlyTheme}
+                onSelectSource={onSelectObject}
+                onComputeEventSeriesFromOrbit={onComputeEventSeriesFromOrbit}
+                onComputeEventSeriesFromSamples={onComputeEventSeriesFromSamples}
+              />
+            ) : (
+              <PlotlyViewport
+                plotId={node.id}
+                data={data}
+                layout={layout}
+                viewRevision={viewRevision}
+                persistView
+                initialView={initialView}
+                testId={`plotly-viewport-${node.id}`}
+                onPointClick={scene || diagram ? handlePointClick : undefined}
+                onResize={scene ? handleResize : undefined}
+              />
+            )}
           </div>
           <div
             className="viewport-resize-handle"
@@ -6366,11 +6411,14 @@ export function ViewportPanel({
   onResizeViewport,
   onToggleViewport,
   onCreateScene,
+  onCreateAnalysis,
   onCreateBifurcation,
   onRenameViewport,
   onDuplicateViewport = () => {},
   onDeleteViewport,
   onSampleMap1DFunction,
+  onComputeEventSeriesFromOrbit,
+  onComputeEventSeriesFromSamples,
   isoclineGeometryCache,
 }: ViewportPanelProps) {
   const [draggingId, setDraggingId] = useState<string | null>(null)
@@ -6405,6 +6453,7 @@ export function ViewportPanel({
   const systemNodes = system.nodes
   const systemObjects = system.objects
   const systemScenes = system.scenes
+  const systemAnalysisViewports = system.analysisViewports
   const systemDiagrams = system.bifurcationDiagrams
   const mapRangeSource = useMemo<VisibleObjectSource>(
     () => ({
@@ -6424,6 +6473,10 @@ export function ViewportPanel({
         const scene = systemScenes.find((entry) => entry.id === nodeId)
         if (!scene) continue
         entries.push({ node, scene })
+      } else if (node.kind === 'analysis') {
+        const analysis = systemAnalysisViewports.find((entry) => entry.id === nodeId)
+        if (!analysis) continue
+        entries.push({ node, analysis })
       } else if (node.kind === 'diagram') {
         const diagram = systemDiagrams.find((entry) => entry.id === nodeId)
         if (!diagram) continue
@@ -6431,7 +6484,7 @@ export function ViewportPanel({
       }
     }
     return entries
-  }, [systemDiagrams, systemNodes, systemRootIds, systemScenes])
+  }, [systemAnalysisViewports, systemDiagrams, systemNodes, systemRootIds, systemScenes])
 
   const hasMapCobwebScene = useMemo(() => {
     return viewports.some((entry) => {
@@ -6680,6 +6733,16 @@ export function ViewportPanel({
       <button
         className="context-menu__item"
         onClick={() => {
+          onCreateAnalysis?.(createMenu.targetId)
+          setCreateMenu(null)
+        }}
+        data-testid="viewport-create-analysis"
+      >
+        Return / Event Map
+      </button>
+      <button
+        className="context-menu__item"
+        onClick={() => {
           onCreateBifurcation(createMenu.targetId)
           setCreateMenu(null)
         }}
@@ -6746,6 +6809,8 @@ export function ViewportPanel({
                 onSelectBranchPoint={onSelectBranchPoint}
                 onSelectOrbitPoint={onSelectOrbitPoint}
                 onSelectLimitCyclePoint={onSelectLimitCyclePoint}
+                onComputeEventSeriesFromOrbit={onComputeEventSeriesFromOrbit}
+                onComputeEventSeriesFromSamples={onComputeEventSeriesFromSamples}
                 onReorderViewport={onReorderViewport}
                 onResizeStart={startResize}
                 onToggleViewport={onToggleViewport}

--- a/web/src/ui/confirmDelete.ts
+++ b/web/src/ui/confirmDelete.ts
@@ -16,6 +16,7 @@ export function confirmDelete({ name, kind }: ConfirmDeleteTarget): boolean {
 export function getDeleteKindLabel(node: TreeNode, system: System): string {
   if (node.kind === 'branch') return 'Branch'
   if (node.kind === 'scene') return 'Scene'
+  if (node.kind === 'analysis') return 'Analysis viewport'
   if (node.kind === 'diagram') return 'Bifurcation diagram'
   if (node.kind === 'camera') return 'Camera'
   if (node.kind === 'object') {


### PR DESCRIPTION
This PR adds support for a new type of viewport (Scenes and Bifurcation Diagrams are the other type of viewports) called Event Map. These are essentially a generalized form of return map plots.

The coding agent was also asked to take a forward view to later implementation of a new type of system (in addition to maps and flows) for analysis, which will use user-supplied data rather than integrating or iterating governing equations. This Event Map feature is intended to follow practices planned for by the agent as it takes this forward view.