### PR TITLE
chore: execute stepped-runner refactor tests

### DIFF
--- a/.github/scripts/refactor_stepped_runner.py
+++ b/.github/scripts/refactor_stepped_runner.py
@@ -1,0 +1,222 @@
+from pathlib import Path
+import re
+
+worker_path = Path('web/src/compute/worker/forkCoreWorker.ts')
+source = worker_path.read_text()
+
+import_anchor = "import type { SystemConfig } from '../../system/types'\n"
+if source.count(import_anchor) != 1:
+    raise SystemExit('Expected one SystemConfig import anchor')
+source = source.replace(
+    import_anchor,
+    import_anchor + "import { runSteppedRunnerToCompletion } from './steppedRunner'\n",
+    1,
+)
+
+batch_helpers = """
+const DEFAULT_PROGRESS_UPDATES = 50
+
+function computeBatchSize(maxSteps: number): number {
+  if (!Number.isFinite(maxSteps) || maxSteps <= 0) return 1
+  return Math.max(1, Math.ceil(maxSteps / DEFAULT_PROGRESS_UPDATES))
+}
+"""
+if source.count(batch_helpers) != 1:
+    raise SystemExit('Expected one local batch helper block')
+source = source.replace(batch_helpers, '', 1)
+
+loop_prefix = (
+    r"  let progress = runner\.get_progress\(\)\n"
+    r"  onProgress\(progress\)\n"
+    r"\n?"
+    r"  const batchSize = computeBatchSize\(progress\.max_steps\)\n"
+    r"  while \(!progress\.done\) \{\n"
+    r"    abortIfNeeded\(signal\)\n"
+    r"    progress = runner\.run_steps\(batchSize\)\n"
+    r"    onProgress\(progress\)\n"
+    r"  \}\n"
+    r"\n?"
+)
+direct_pattern = re.compile(loop_prefix + r"  return runner\.get_result\(\)")
+source, direct_count = direct_pattern.subn(
+    '  return runSteppedRunnerToCompletion(runner, signal, onProgress)',
+    source,
+)
+if direct_count != 15:
+    raise SystemExit(f'Expected 15 direct runner loops, replaced {direct_count}')
+
+transformed_pattern = re.compile(
+    loop_prefix
+    + r"  return discardHomoclinicInitialApproximationPoint\(runner\.get_result\(\)\)"
+)
+source, transformed_count = transformed_pattern.subn(
+    "  return discardHomoclinicInitialApproximationPoint(\n"
+    "    runSteppedRunnerToCompletion(runner, signal, onProgress)\n"
+    "  )",
+    source,
+)
+if transformed_count != 1:
+    raise SystemExit(f'Expected one transformed runner loop, replaced {transformed_count}')
+
+if 'computeBatchSize' in source:
+    raise SystemExit('Local batch helper references remain')
+if 'let progress = runner.get_progress()' in source:
+    raise SystemExit('Duplicated stepped runner loops remain')
+worker_path.write_text(source)
+
+Path('web/src/compute/worker/steppedRunner.ts').write_text("""import type { ContinuationProgress } from '../ForkCoreClient'
+
+const DEFAULT_PROGRESS_UPDATES = 50
+
+export type SteppedRunner<TResult> = {
+  get_progress: () => ContinuationProgress
+  run_steps: (batchSize: number) => ContinuationProgress
+  get_result: () => TResult
+}
+
+function computeBatchSize(maxSteps: number): number {
+  if (!Number.isFinite(maxSteps) || maxSteps <= 0) return 1
+  return Math.max(1, Math.ceil(maxSteps / DEFAULT_PROGRESS_UPDATES))
+}
+
+function abortIfNeeded(signal: AbortSignal): void {
+  if (!signal.aborted) return
+  const error = new Error('cancelled')
+  error.name = 'AbortError'
+  throw error
+}
+
+export function runSteppedRunnerToCompletion<TResult>(
+  runner: SteppedRunner<TResult>,
+  signal: AbortSignal,
+  onProgress: (progress: ContinuationProgress) => void
+): TResult {
+  let progress = runner.get_progress()
+  onProgress(progress)
+
+  const batchSize = computeBatchSize(progress.max_steps)
+  while (!progress.done) {
+    abortIfNeeded(signal)
+    progress = runner.run_steps(batchSize)
+    onProgress(progress)
+  }
+
+  return runner.get_result()
+}
+""")
+
+Path('web/src/compute/worker/steppedRunner.test.ts').write_text("""import { describe, expect, it, vi } from 'vitest'
+import type { ContinuationProgress } from '../ForkCoreClient'
+import { runSteppedRunnerToCompletion } from './steppedRunner'
+
+function makeProgress(
+  currentStep: number,
+  maxSteps: number,
+  done: boolean
+): ContinuationProgress {
+  return {
+    done,
+    current_step: currentStep,
+    max_steps: maxSteps,
+    points_computed: currentStep,
+    bifurcations_found: 0,
+    current_param: currentStep,
+  }
+}
+
+describe('runSteppedRunnerToCompletion', () => {
+  it('drains the runner with bounded batches and reports every progress value', () => {
+    let currentStep = 0
+    const runSteps = vi.fn((batchSize: number) => {
+      currentStep = Math.min(100, currentStep + batchSize)
+      return makeProgress(currentStep, 100, currentStep === 100)
+    })
+    const getResult = vi.fn(() => ({ points: 100 }))
+    const runner = {
+      get_progress: vi.fn(() => makeProgress(0, 100, false)),
+      run_steps: runSteps,
+      get_result: getResult,
+    }
+    const onProgress = vi.fn()
+
+    const result = runSteppedRunnerToCompletion(
+      runner,
+      new AbortController().signal,
+      onProgress
+    )
+
+    expect(result).toEqual({ points: 100 })
+    expect(runSteps).toHaveBeenCalledTimes(50)
+    expect(runSteps).toHaveBeenNthCalledWith(1, 2)
+    expect(onProgress).toHaveBeenCalledTimes(51)
+    expect(onProgress.mock.calls[0]?.[0]).toEqual(makeProgress(0, 100, false))
+    expect(onProgress.mock.calls.at(-1)?.[0]).toEqual(makeProgress(100, 100, true))
+    expect(getResult).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses a batch size of one when max steps is not positive', () => {
+    const runSteps = vi.fn(() => makeProgress(1, 0, true))
+    const runner = {
+      get_progress: vi.fn(() => makeProgress(0, 0, false)),
+      run_steps: runSteps,
+      get_result: vi.fn(() => 'complete'),
+    }
+
+    expect(
+      runSteppedRunnerToCompletion(
+        runner,
+        new AbortController().signal,
+        vi.fn()
+      )
+    ).toBe('complete')
+    expect(runSteps).toHaveBeenCalledExactlyOnceWith(1)
+  })
+
+  it('returns immediately when the runner is already done', () => {
+    const runSteps = vi.fn()
+    const getResult = vi.fn(() => 'complete')
+    const onProgress = vi.fn()
+    const runner = {
+      get_progress: vi.fn(() => makeProgress(0, 0, true)),
+      run_steps: runSteps,
+      get_result: getResult,
+    }
+
+    expect(
+      runSteppedRunnerToCompletion(
+        runner,
+        new AbortController().signal,
+        onProgress
+      )
+    ).toBe('complete')
+    expect(runSteps).not.toHaveBeenCalled()
+    expect(onProgress).toHaveBeenCalledExactlyOnceWith(makeProgress(0, 0, true))
+    expect(getResult).toHaveBeenCalledTimes(1)
+  })
+
+  it('checks cancellation before running the next batch', () => {
+    const controller = new AbortController()
+    const runSteps = vi.fn(() => makeProgress(1, 10, true))
+    const getResult = vi.fn(() => 'complete')
+    const runner = {
+      get_progress: vi.fn(() => makeProgress(0, 10, false)),
+      run_steps: runSteps,
+      get_result: getResult,
+    }
+    let thrown: unknown
+
+    try {
+      runSteppedRunnerToCompletion(runner, controller.signal, () => {
+        controller.abort()
+      })
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect((thrown as Error).name).toBe('AbortError')
+    expect(runSteps).not.toHaveBeenCalled()
+    expect(getResult).not.toHaveBeenCalled()
+  })
+})
+""")

--- a/.github/scripts/refactor_stepped_runner.py
+++ b/.github/scripts/refactor_stepped_runner.py
@@ -169,7 +169,8 @@ describe('runSteppedRunnerToCompletion', () => {
         vi.fn()
       )
     ).toBe('complete')
-    expect(runSteps).toHaveBeenCalledExactlyOnceWith(1)
+    expect(runSteps).toHaveBeenCalledTimes(1)
+    expect(runSteps).toHaveBeenCalledWith(1)
   })
 
   it('returns immediately when the runner is already done', () => {
@@ -190,7 +191,8 @@ describe('runSteppedRunnerToCompletion', () => {
       )
     ).toBe('complete')
     expect(runSteps).not.toHaveBeenCalled()
-    expect(onProgress).toHaveBeenCalledExactlyOnceWith(makeProgress(0, 0, true))
+    expect(onProgress).toHaveBeenCalledTimes(1)
+    expect(onProgress).toHaveBeenCalledWith(makeProgress(0, 0, true))
     expect(getResult).toHaveBeenCalledTimes(1)
   })
 

--- a/.github/workflows/temporary-stepped-runner-pr.yml
+++ b/.github/workflows/temporary-stepped-runner-pr.yml
@@ -1,0 +1,96 @@
+name: Temporary stepped runner PR executor
+
+on:
+  pull_request:
+    branches:
+      - refactor/web-stepped-runner-executor
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refactor-test-commit:
+    if: github.repository == 'hinsley/Fork'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out automation source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: automation
+
+      - name: Check out target branch
+        uses: actions/checkout@v4
+        with:
+          ref: refactor/web-stepped-runner-executor
+          fetch-depth: 0
+          path: target
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: target/web/package-lock.json
+
+      - name: Install web dependencies
+        working-directory: target/web
+        run: npm ci
+
+      - name: Apply stepped runner refactor
+        working-directory: target
+        run: python ../automation/.github/scripts/refactor_stepped_runner.py
+
+      - name: Verify refactor shape
+        working-directory: target
+        shell: bash
+        run: |
+          git diff --check
+          test "$(grep -c "runSteppedRunnerToCompletion" web/src/compute/worker/forkCoreWorker.ts)" -eq 17
+          ! grep -q "computeBatchSize" web/src/compute/worker/forkCoreWorker.ts
+          ! grep -q "let progress = runner.get_progress()" web/src/compute/worker/forkCoreWorker.ts
+
+      - name: Lint web
+        working-directory: target/web
+        run: npm run lint
+
+      - name: Run web unit tests
+        working-directory: target/web
+        run: npm run test:unit
+
+      - name: Build web
+        working-directory: target/web
+        run: npm run build
+
+      - name: Commit tested refactor
+        working-directory: target
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            web/src/compute/worker/forkCoreWorker.ts \
+            web/src/compute/worker/steppedRunner.ts \
+            web/src/compute/worker/steppedRunner.test.ts
+          git diff --cached --check
+          git commit -m "refactor(web): centralize stepped runner execution"
+          git push origin HEAD:refs/heads/refactor/web-stepped-runner-executor
+
+      - name: Close and remove temporary PR branch
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr close "$PR_NUMBER" \
+            --repo hinsley/Fork \
+            --comment "Automation completed: the tested refactor was committed to refactor/web-stepped-runner-executor." \
+            --delete-branch

--- a/.github/workflows/temporary-stepped-runner-pr.yml
+++ b/.github/workflows/temporary-stepped-runner-pr.yml
@@ -86,9 +86,15 @@ jobs:
           } > /tmp/test-comment.md
           gh pr comment "$PR_NUMBER" --repo hinsley/Fork --body-file /tmp/test-comment.md
 
+      - name: Build web and WASM
+        id: build
+        if: steps.focused-tests.outcome == 'success'
+        working-directory: target/web
+        run: npm run build
+
       - name: Run worker integration tests
         id: worker-tests
-        if: steps.focused-tests.outcome == 'success'
+        if: steps.build.outcome == 'success'
         working-directory: target/web
         shell: bash
         run: |
@@ -133,11 +139,6 @@ jobs:
             echo '```'
           } > /tmp/test-comment.md
           gh pr comment "$PR_NUMBER" --repo hinsley/Fork --body-file /tmp/test-comment.md
-
-      - name: Build web
-        if: steps.unit-tests.outcome == 'success'
-        working-directory: target/web
-        run: npm run build
 
       - name: Commit tested refactor
         if: success()

--- a/.github/workflows/temporary-stepped-runner-pr.yml
+++ b/.github/workflows/temporary-stepped-runner-pr.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:
@@ -62,15 +63,60 @@ jobs:
         working-directory: target/web
         run: npm run lint
 
-      - name: Run web unit tests
+      - name: Run focused stepped runner tests
+        id: focused-tests
         working-directory: target/web
-        run: npm run test:unit
+        shell: bash
+        run: |
+          set -o pipefail
+          npm run test:unit -- src/compute/worker/steppedRunner.test.ts 2>&1 | tee /tmp/focused-tests.log
+
+      - name: Report focused test failure
+        if: always() && steps.focused-tests.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          {
+            echo 'Focused stepped-runner test failure:'
+            echo '```text'
+            tail -n 180 /tmp/focused-tests.log
+            echo '```'
+          } > /tmp/test-comment.md
+          gh pr comment "$PR_NUMBER" --repo hinsley/Fork --body-file /tmp/test-comment.md
+
+      - name: Run web unit tests
+        id: unit-tests
+        if: steps.focused-tests.outcome == 'success'
+        working-directory: target/web
+        shell: bash
+        run: |
+          set -o pipefail
+          npm run test:unit 2>&1 | tee /tmp/unit-tests.log
+
+      - name: Report unit test failure
+        if: always() && steps.unit-tests.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          {
+            echo 'Full web unit-suite failure:'
+            echo '```text'
+            tail -n 180 /tmp/unit-tests.log
+            echo '```'
+          } > /tmp/test-comment.md
+          gh pr comment "$PR_NUMBER" --repo hinsley/Fork --body-file /tmp/test-comment.md
 
       - name: Build web
+        if: steps.unit-tests.outcome == 'success'
         working-directory: target/web
         run: npm run build
 
       - name: Commit tested refactor
+        if: success()
         working-directory: target
         shell: bash
         run: |

--- a/.github/workflows/temporary-stepped-runner-pr.yml
+++ b/.github/workflows/temporary-stepped-runner-pr.yml
@@ -81,14 +81,38 @@ jobs:
           {
             echo 'Focused stepped-runner test failure:'
             echo '```text'
-            tail -n 180 /tmp/focused-tests.log
+            tail -n 100 /tmp/focused-tests.log
+            echo '```'
+          } > /tmp/test-comment.md
+          gh pr comment "$PR_NUMBER" --repo hinsley/Fork --body-file /tmp/test-comment.md
+
+      - name: Run worker integration tests
+        id: worker-tests
+        if: steps.focused-tests.outcome == 'success'
+        working-directory: target/web
+        shell: bash
+        run: |
+          set -o pipefail
+          npm run test:unit -- src/compute/worker/forkCoreWorker.test.ts --reporter=verbose 2>&1 | tee /tmp/worker-tests.log
+
+      - name: Report worker integration failure
+        if: always() && steps.worker-tests.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          {
+            echo 'Worker integration-test failure:'
+            echo '```text'
+            tail -n 100 /tmp/worker-tests.log
             echo '```'
           } > /tmp/test-comment.md
           gh pr comment "$PR_NUMBER" --repo hinsley/Fork --body-file /tmp/test-comment.md
 
       - name: Run web unit tests
         id: unit-tests
-        if: steps.focused-tests.outcome == 'success'
+        if: steps.worker-tests.outcome == 'success'
         working-directory: target/web
         shell: bash
         run: |
@@ -105,7 +129,7 @@ jobs:
           {
             echo 'Full web unit-suite failure:'
             echo '```text'
-            tail -n 180 /tmp/unit-tests.log
+            tail -n 60 /tmp/unit-tests.log
             echo '```'
           } > /tmp/test-comment.md
           gh pr comment "$PR_NUMBER" --repo hinsley/Fork --body-file /tmp/test-comment.md

--- a/.github/workflows/temporary-stepped-runner-refactor.yml
+++ b/.github/workflows/temporary-stepped-runner-refactor.yml
@@ -1,0 +1,304 @@
+name: Temporary stepped runner refactor
+
+on:
+  push:
+    branches:
+      - automation/refactor-web-stepped-runner
+
+permissions:
+  contents: write
+
+jobs:
+  refactor-test-commit:
+    if: github.repository == 'hinsley/Fork'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out target branch
+        uses: actions/checkout@v4
+        with:
+          ref: refactor/web-stepped-runner-executor
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install web dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Apply stepped runner refactor
+        shell: bash
+        run: |
+          python <<'PY'
+          from pathlib import Path
+          import re
+
+          worker_path = Path('web/src/compute/worker/forkCoreWorker.ts')
+          source = worker_path.read_text()
+
+          import_anchor = "import type { SystemConfig } from '../../system/types'\n"
+          if source.count(import_anchor) != 1:
+              raise SystemExit('Expected one SystemConfig import anchor')
+          source = source.replace(
+              import_anchor,
+              import_anchor + "import { runSteppedRunnerToCompletion } from './steppedRunner'\n",
+              1,
+          )
+
+          batch_helpers = """
+          const DEFAULT_PROGRESS_UPDATES = 50
+
+          function computeBatchSize(maxSteps: number): number {
+            if (!Number.isFinite(maxSteps) || maxSteps <= 0) return 1
+            return Math.max(1, Math.ceil(maxSteps / DEFAULT_PROGRESS_UPDATES))
+          }
+          """
+          if source.count(batch_helpers) != 1:
+              raise SystemExit('Expected one local batch helper block')
+          source = source.replace(batch_helpers, '', 1)
+
+          loop_prefix = (
+              r"  let progress = runner\.get_progress\(\)\n"
+              r"  onProgress\(progress\)\n"
+              r"\n?"
+              r"  const batchSize = computeBatchSize\(progress\.max_steps\)\n"
+              r"  while \(!progress\.done\) \{\n"
+              r"    abortIfNeeded\(signal\)\n"
+              r"    progress = runner\.run_steps\(batchSize\)\n"
+              r"    onProgress\(progress\)\n"
+              r"  \}\n"
+              r"\n?"
+          )
+          direct_pattern = re.compile(loop_prefix + r"  return runner\.get_result\(\)")
+          source, direct_count = direct_pattern.subn(
+              '  return runSteppedRunnerToCompletion(runner, signal, onProgress)',
+              source,
+          )
+          if direct_count != 15:
+              raise SystemExit(f'Expected 15 direct runner loops, replaced {direct_count}')
+
+          transformed_pattern = re.compile(
+              loop_prefix
+              + r"  return discardHomoclinicInitialApproximationPoint\(runner\.get_result\(\)\)"
+          )
+          source, transformed_count = transformed_pattern.subn(
+              "  return discardHomoclinicInitialApproximationPoint(\n"
+              "    runSteppedRunnerToCompletion(runner, signal, onProgress)\n"
+              "  )",
+              source,
+          )
+          if transformed_count != 1:
+              raise SystemExit(
+                  f'Expected one transformed runner loop, replaced {transformed_count}'
+              )
+
+          if 'computeBatchSize' in source:
+              raise SystemExit('Local batch helper references remain')
+          if 'let progress = runner.get_progress()' in source:
+              raise SystemExit('Duplicated stepped runner loops remain')
+          worker_path.write_text(source)
+
+          Path('web/src/compute/worker/steppedRunner.ts').write_text("""import type { ContinuationProgress } from '../ForkCoreClient'
+
+const DEFAULT_PROGRESS_UPDATES = 50
+
+export type SteppedRunner<TResult> = {
+  get_progress: () => ContinuationProgress
+  run_steps: (batchSize: number) => ContinuationProgress
+  get_result: () => TResult
+}
+
+function computeBatchSize(maxSteps: number): number {
+  if (!Number.isFinite(maxSteps) || maxSteps <= 0) return 1
+  return Math.max(1, Math.ceil(maxSteps / DEFAULT_PROGRESS_UPDATES))
+}
+
+function abortIfNeeded(signal: AbortSignal): void {
+  if (!signal.aborted) return
+  const error = new Error('cancelled')
+  error.name = 'AbortError'
+  throw error
+}
+
+export function runSteppedRunnerToCompletion<TResult>(
+  runner: SteppedRunner<TResult>,
+  signal: AbortSignal,
+  onProgress: (progress: ContinuationProgress) => void
+): TResult {
+  let progress = runner.get_progress()
+  onProgress(progress)
+
+  const batchSize = computeBatchSize(progress.max_steps)
+  while (!progress.done) {
+    abortIfNeeded(signal)
+    progress = runner.run_steps(batchSize)
+    onProgress(progress)
+  }
+
+  return runner.get_result()
+}
+""")
+
+          Path('web/src/compute/worker/steppedRunner.test.ts').write_text("""import { describe, expect, it, vi } from 'vitest'
+import type { ContinuationProgress } from '../ForkCoreClient'
+import { runSteppedRunnerToCompletion } from './steppedRunner'
+
+function makeProgress(
+  currentStep: number,
+  maxSteps: number,
+  done: boolean
+): ContinuationProgress {
+  return {
+    done,
+    current_step: currentStep,
+    max_steps: maxSteps,
+    points_computed: currentStep,
+    bifurcations_found: 0,
+    current_param: currentStep,
+  }
+}
+
+describe('runSteppedRunnerToCompletion', () => {
+  it('drains the runner with bounded batches and reports every progress value', () => {
+    let currentStep = 0
+    const runSteps = vi.fn((batchSize: number) => {
+      currentStep = Math.min(100, currentStep + batchSize)
+      return makeProgress(currentStep, 100, currentStep === 100)
+    })
+    const getResult = vi.fn(() => ({ points: 100 }))
+    const runner = {
+      get_progress: vi.fn(() => makeProgress(0, 100, false)),
+      run_steps: runSteps,
+      get_result: getResult,
+    }
+    const onProgress = vi.fn()
+
+    const result = runSteppedRunnerToCompletion(
+      runner,
+      new AbortController().signal,
+      onProgress
+    )
+
+    expect(result).toEqual({ points: 100 })
+    expect(runSteps).toHaveBeenCalledTimes(50)
+    expect(runSteps).toHaveBeenNthCalledWith(1, 2)
+    expect(onProgress).toHaveBeenCalledTimes(51)
+    expect(onProgress.mock.calls[0]?.[0]).toEqual(makeProgress(0, 100, false))
+    expect(onProgress.mock.calls.at(-1)?.[0]).toEqual(makeProgress(100, 100, true))
+    expect(getResult).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses a batch size of one when max steps is not positive', () => {
+    const runSteps = vi.fn(() => makeProgress(1, 0, true))
+    const runner = {
+      get_progress: vi.fn(() => makeProgress(0, 0, false)),
+      run_steps: runSteps,
+      get_result: vi.fn(() => 'complete'),
+    }
+
+    expect(
+      runSteppedRunnerToCompletion(
+        runner,
+        new AbortController().signal,
+        vi.fn()
+      )
+    ).toBe('complete')
+    expect(runSteps).toHaveBeenCalledExactlyOnceWith(1)
+  })
+
+  it('returns immediately when the runner is already done', () => {
+    const runSteps = vi.fn()
+    const getResult = vi.fn(() => 'complete')
+    const onProgress = vi.fn()
+    const runner = {
+      get_progress: vi.fn(() => makeProgress(0, 0, true)),
+      run_steps: runSteps,
+      get_result: getResult,
+    }
+
+    expect(
+      runSteppedRunnerToCompletion(
+        runner,
+        new AbortController().signal,
+        onProgress
+      )
+    ).toBe('complete')
+    expect(runSteps).not.toHaveBeenCalled()
+    expect(onProgress).toHaveBeenCalledExactlyOnceWith(makeProgress(0, 0, true))
+    expect(getResult).toHaveBeenCalledTimes(1)
+  })
+
+  it('checks cancellation before running the next batch', () => {
+    const controller = new AbortController()
+    const runSteps = vi.fn(() => makeProgress(1, 10, true))
+    const getResult = vi.fn(() => 'complete')
+    const runner = {
+      get_progress: vi.fn(() => makeProgress(0, 10, false)),
+      run_steps: runSteps,
+      get_result: getResult,
+    }
+    let thrown: unknown
+
+    try {
+      runSteppedRunnerToCompletion(runner, controller.signal, () => {
+        controller.abort()
+      })
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect((thrown as Error).name).toBe('AbortError')
+    expect(runSteps).not.toHaveBeenCalled()
+    expect(getResult).not.toHaveBeenCalled()
+  })
+})
+""")
+          PY
+
+      - name: Verify refactor shape
+        shell: bash
+        run: |
+          git diff --check
+          test "$(grep -c "runSteppedRunnerToCompletion" web/src/compute/worker/forkCoreWorker.ts)" -eq 17
+          ! grep -q "computeBatchSize" web/src/compute/worker/forkCoreWorker.ts
+          ! grep -q "let progress = runner.get_progress()" web/src/compute/worker/forkCoreWorker.ts
+
+      - name: Lint web
+        working-directory: web
+        run: npm run lint
+
+      - name: Run web unit tests
+        working-directory: web
+        run: npm run test:unit
+
+      - name: Build web
+        working-directory: web
+        run: npm run build
+
+      - name: Commit tested refactor
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            web/src/compute/worker/forkCoreWorker.ts \
+            web/src/compute/worker/steppedRunner.ts \
+            web/src/compute/worker/steppedRunner.test.ts
+          git diff --cached --check
+          git commit -m "refactor(web): centralize stepped runner execution"
+          git push origin HEAD:refs/heads/refactor/web-stepped-runner-executor
+          git push origin --delete automation/refactor-web-stepped-runner || true


### PR DESCRIPTION
Temporary automation PR into the feature branch. It applies the stepped-runner refactor, runs web lint/unit/build checks, commits the tested result to `refactor/web-stepped-runner-executor`, then closes and deletes this branch. This is not the eventual PR to `main`.