### PR TITLE
refactor(web): centralize stepped runner execution

### DIFF
--- a/web/src/compute/worker/forkCoreWorker.ts
+++ b/web/src/compute/worker/forkCoreWorker.ts
@@ -54,6 +54,7 @@ import type {
 import { discardHomoclinicInitialApproximationPoint } from '../../system/continuation'
 import { periodicPeriodsForConfig } from '../../system/periodicity'
 import type { SystemConfig } from '../../system/types'
+import { runSteppedRunnerToCompletion } from './steppedRunner'
 
 type WorkerRequest =
   | { id: string; kind: 'simulateOrbit'; payload: SimulateOrbitRequest }
@@ -807,13 +808,6 @@ async function runSolveEquilibrium(
   )
 }
 
-const DEFAULT_PROGRESS_UPDATES = 50
-
-function computeBatchSize(maxSteps: number): number {
-  if (!Number.isFinite(maxSteps) || maxSteps <= 0) return 1
-  return Math.max(1, Math.ceil(maxSteps / DEFAULT_PROGRESS_UPDATES))
-}
-
 async function runEquilibriumContinuation(
   request: EquilibriumContinuationRequest,
   signal: AbortSignal,
@@ -838,17 +832,7 @@ async function runEquilibriumContinuation(
     new Float64Array(periodicPeriodsForConfig(request.system))
   )
 
-  let progress = runner.get_progress()
-  onProgress(progress)
-
-  const batchSize = computeBatchSize(progress.max_steps)
-  while (!progress.done) {
-    abortIfNeeded(signal)
-    progress = runner.run_steps(batchSize)
-    onProgress(progress)
-  }
-
-  return runner.get_result()
+  return runSteppedRunnerToCompletion(runner, signal, onProgress)
 }
 
 function isCodim1BranchType(branchType: unknown): boolean {
@@ -902,17 +886,7 @@ async function runContinuationExtension(
         request.forward
       )
 
-  let progress = runner.get_progress()
-  onProgress(progress)
-
-  const batchSize = computeBatchSize(progress.max_steps)
-  while (!progress.done) {
-    abortIfNeeded(signal)
-    progress = runner.run_steps(batchSize)
-    onProgress(progress)
-  }
-
-  return runner.get_result()
+  return runSteppedRunnerToCompletion(runner, signal, onProgress)
 }
 
 async function runEquilibriumManifold1D(
@@ -933,15 +907,7 @@ async function runEquilibriumManifold1D(
     { ...request.settings },
     new Float64Array(periodicPeriodsForConfig(request.system))
   )
-  let progress = runner.get_progress()
-  onProgress(progress)
-  const batchSize = computeBatchSize(progress.max_steps)
-  while (!progress.done) {
-    abortIfNeeded(signal)
-    progress = runner.run_steps(batchSize)
-    onProgress(progress)
-  }
-  return runner.get_result()
+  return runSteppedRunnerToCompletion(runner, signal, onProgress)
 }
 
 async function runEquilibriumManifold1DExtension(
@@ -962,15 +928,7 @@ async function runEquilibriumManifold1DExtension(
     { ...request.settings },
     new Float64Array(periodicPeriodsForConfig(request.system))
   )
-  let progress = runner.get_progress()
-  onProgress(progress)
-  const batchSize = computeBatchSize(progress.max_steps)
-  while (!progress.done) {
-    abortIfNeeded(signal)
-    progress = runner.run_steps(batchSize)
-    onProgress(progress)
-  }
-  return runner.get_result()
+  return runSteppedRunnerToCompletion(runner, signal, onProgress)
 }
 
 async function runManifold2DExtension(
@@ -989,15 +947,7 @@ async function runManifold2DExtension(
     request.branchData,
     { ...request.settings }
   )
-  let progress = runner.get_progress()
-  onProgress(progress)
-  const batchSize = computeBatchSize(progress.max_steps)
-  while (!progress.done) {
-    abortIfNeeded(signal)
-    progress = runner.run_steps(batchSize)
-    onProgress(progress)
-  }
-  return runner.get_result()
+  return runSteppedRunnerToCompletion(runner, signal, onProgress)
 }
 
 async function runEquilibriumManifold2D(
@@ -1030,15 +980,7 @@ async function runEquilibriumManifold2D(
     new Float64Array(request.equilibriumState),
     { ...request.settings }
   )
-  let progress = runner.get_progress()
-  onProgress(progress)
-  const batchSize = computeBatchSize(progress.max_steps)
-  while (!progress.done) {
-    abortIfNeeded(signal)
-    progress = runner.run_steps(batchSize)
-    onProgress(progress)
-  }
-  return runner.get_result()
+  return runSteppedRunnerToCompletion(runner, signal, onProgress)
 }
 
 async function runLimitCycleManifold2D(
@@ -1077,15 +1019,7 @@ async function runLimitCycleManifold2D(
     request.floquetMultipliers,
     { ...request.settings }
   )
-  let progress = runner.get_progress()
-  onProgress(progress)
-  const batchSize = computeBatchSize(progress.max_steps)
-  while (!progress.done) {
-    abortIfNeeded(signal)
-    progress = runner.run_steps(batchSize)
-    onProgress(progress)
-  }
-  return runner.get_result()
+  return runSteppedRunnerToCompletion(runner, signal, onProgress)
 }
 
 async function runComputeLimitCycleFloquetModes(
@@ -1137,17 +1071,7 @@ async function runFoldCurveContinuation(
     request.forward
   )
 
-  let progress = runner.get_progress()
-  onProgress(progress)
-
-  const batchSize = computeBatchSize(progress.max_steps)
-  while (!progress.done) {
-    abortIfNeeded(signal)
-    progress = runner.run_steps(batchSize)
-    onProgress(progress)
-  }
-
-  return runner.get_result()
+  return runSteppedRunnerToCompletion(runner, signal, onProgress)
 }
 
 async function runHopfCurveContinuation(
@@ -1177,17 +1101,7 @@ async function runHopfCurveContinuation(
     request.forward
   )
 
-  let progress = runner.get_progress()
-  onProgress(progress)
-
-  const batchSize = computeBatchSize(progress.max_steps)
-  while (!progress.done) {
-    abortIfNeeded(signal)
-    progress = runner.run_steps(batchSize)
-    onProgress(progress)
-  }
-
-  return runner.get_result()
+  return runSteppedRunnerToCompletion(runner, signal, onProgress)
 }
 
 async function runIsochroneCurveContinuation(
@@ -1280,17 +1194,7 @@ async function runIsochroneCurveContinuation(
     request.forward
   )
 
-  let progress = runner.get_progress()
-  onProgress(progress)
-
-  const batchSize = computeBatchSize(progress.max_steps)
-  while (!progress.done) {
-    abortIfNeeded(signal)
-    progress = runner.run_steps(batchSize)
-    onProgress(progress)
-  }
-
-  return runner.get_result()
+  return runSteppedRunnerToCompletion(runner, signal, onProgress)
 }
 
 async function runLimitCycleContinuationFromHopf(
@@ -1324,17 +1228,7 @@ async function runLimitCycleContinuationFromHopf(
     request.forward
   )
 
-  let progress = runner.get_progress()
-  onProgress(progress)
-
-  const batchSize = computeBatchSize(progress.max_steps)
-  while (!progress.done) {
-    abortIfNeeded(signal)
-    progress = runner.run_steps(batchSize)
-    onProgress(progress)
-  }
-
-  return runner.get_result()
+  return runSteppedRunnerToCompletion(runner, signal, onProgress)
 }
 
 async function runLimitCycleContinuationFromOrbit(
@@ -1370,17 +1264,7 @@ async function runLimitCycleContinuationFromOrbit(
     request.forward
   )
 
-  let progress = runner.get_progress()
-  onProgress(progress)
-
-  const batchSize = computeBatchSize(progress.max_steps)
-  while (!progress.done) {
-    abortIfNeeded(signal)
-    progress = runner.run_steps(batchSize)
-    onProgress(progress)
-  }
-
-  return runner.get_result()
+  return runSteppedRunnerToCompletion(runner, signal, onProgress)
 }
 
 async function runLimitCycleContinuationFromPD(
@@ -1414,17 +1298,7 @@ async function runLimitCycleContinuationFromPD(
     request.forward
   )
 
-  let progress = runner.get_progress()
-  onProgress(progress)
-
-  const batchSize = computeBatchSize(progress.max_steps)
-  while (!progress.done) {
-    abortIfNeeded(signal)
-    progress = runner.run_steps(batchSize)
-    onProgress(progress)
-  }
-
-  return runner.get_result()
+  return runSteppedRunnerToCompletion(runner, signal, onProgress)
 }
 
 async function runHomoclinicFromLargeCycle(
@@ -1473,17 +1347,9 @@ async function runHomoclinicFromLargeCycle(
     request.forward
   )
 
-  let progress = runner.get_progress()
-  onProgress(progress)
-
-  const batchSize = computeBatchSize(progress.max_steps)
-  while (!progress.done) {
-    abortIfNeeded(signal)
-    progress = runner.run_steps(batchSize)
-    onProgress(progress)
-  }
-
-  return discardHomoclinicInitialApproximationPoint(runner.get_result())
+  return discardHomoclinicInitialApproximationPoint(
+    runSteppedRunnerToCompletion(runner, signal, onProgress)
+  )
 }
 
 async function runHomoclinicFromHomoclinic(
@@ -1538,17 +1404,7 @@ async function runHomoclinicFromHomoclinic(
     request.forward
   )
 
-  let progress = runner.get_progress()
-  onProgress(progress)
-
-  const batchSize = computeBatchSize(progress.max_steps)
-  while (!progress.done) {
-    abortIfNeeded(signal)
-    progress = runner.run_steps(batchSize)
-    onProgress(progress)
-  }
-
-  return runner.get_result()
+  return runSteppedRunnerToCompletion(runner, signal, onProgress)
 }
 
 async function runHomotopySaddleFromEquilibrium(
@@ -1596,17 +1452,7 @@ async function runHomotopySaddleFromEquilibrium(
     request.forward
   )
 
-  let progress = runner.get_progress()
-  onProgress(progress)
-
-  const batchSize = computeBatchSize(progress.max_steps)
-  while (!progress.done) {
-    abortIfNeeded(signal)
-    progress = runner.run_steps(batchSize)
-    onProgress(progress)
-  }
-
-  return runner.get_result()
+  return runSteppedRunnerToCompletion(runner, signal, onProgress)
 }
 
 async function runHomoclinicFromHomotopySaddle(
@@ -1655,17 +1501,7 @@ async function runHomoclinicFromHomotopySaddle(
     request.forward
   )
 
-  let progress = runner.get_progress()
-  onProgress(progress)
-
-  const batchSize = computeBatchSize(progress.max_steps)
-  while (!progress.done) {
-    abortIfNeeded(signal)
-    progress = runner.run_steps(batchSize)
-    onProgress(progress)
-  }
-
-  return runner.get_result()
+  return runSteppedRunnerToCompletion(runner, signal, onProgress)
 }
 
 async function runMapCycleContinuationFromPD(

--- a/web/src/compute/worker/steppedRunner.test.ts
+++ b/web/src/compute/worker/steppedRunner.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ContinuationProgress } from '../ForkCoreClient'
+import { runSteppedRunnerToCompletion } from './steppedRunner'
+
+function makeProgress(
+  currentStep: number,
+  maxSteps: number,
+  done: boolean
+): ContinuationProgress {
+  return {
+    done,
+    current_step: currentStep,
+    max_steps: maxSteps,
+    points_computed: currentStep,
+    bifurcations_found: 0,
+    current_param: currentStep,
+  }
+}
+
+describe('runSteppedRunnerToCompletion', () => {
+  it('drains the runner with bounded batches and reports every progress value', () => {
+    let currentStep = 0
+    const runSteps = vi.fn((batchSize: number) => {
+      currentStep = Math.min(100, currentStep + batchSize)
+      return makeProgress(currentStep, 100, currentStep === 100)
+    })
+    const getResult = vi.fn(() => ({ points: 100 }))
+    const runner = {
+      get_progress: vi.fn(() => makeProgress(0, 100, false)),
+      run_steps: runSteps,
+      get_result: getResult,
+    }
+    const onProgress = vi.fn()
+
+    const result = runSteppedRunnerToCompletion(
+      runner,
+      new AbortController().signal,
+      onProgress
+    )
+
+    expect(result).toEqual({ points: 100 })
+    expect(runSteps).toHaveBeenCalledTimes(50)
+    expect(runSteps).toHaveBeenNthCalledWith(1, 2)
+    expect(onProgress).toHaveBeenCalledTimes(51)
+    expect(onProgress.mock.calls[0]?.[0]).toEqual(makeProgress(0, 100, false))
+    expect(onProgress.mock.calls.at(-1)?.[0]).toEqual(makeProgress(100, 100, true))
+    expect(getResult).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses a batch size of one when max steps is not positive', () => {
+    const runSteps = vi.fn(() => makeProgress(1, 0, true))
+    const runner = {
+      get_progress: vi.fn(() => makeProgress(0, 0, false)),
+      run_steps: runSteps,
+      get_result: vi.fn(() => 'complete'),
+    }
+
+    expect(
+      runSteppedRunnerToCompletion(
+        runner,
+        new AbortController().signal,
+        vi.fn()
+      )
+    ).toBe('complete')
+    expect(runSteps).toHaveBeenCalledTimes(1)
+    expect(runSteps).toHaveBeenCalledWith(1)
+  })
+
+  it('returns immediately when the runner is already done', () => {
+    const runSteps = vi.fn()
+    const getResult = vi.fn(() => 'complete')
+    const onProgress = vi.fn()
+    const runner = {
+      get_progress: vi.fn(() => makeProgress(0, 0, true)),
+      run_steps: runSteps,
+      get_result: getResult,
+    }
+
+    expect(
+      runSteppedRunnerToCompletion(
+        runner,
+        new AbortController().signal,
+        onProgress
+      )
+    ).toBe('complete')
+    expect(runSteps).not.toHaveBeenCalled()
+    expect(onProgress).toHaveBeenCalledTimes(1)
+    expect(onProgress).toHaveBeenCalledWith(makeProgress(0, 0, true))
+    expect(getResult).toHaveBeenCalledTimes(1)
+  })
+
+  it('checks cancellation before running the next batch', () => {
+    const controller = new AbortController()
+    const runSteps = vi.fn(() => makeProgress(1, 10, true))
+    const getResult = vi.fn(() => 'complete')
+    const runner = {
+      get_progress: vi.fn(() => makeProgress(0, 10, false)),
+      run_steps: runSteps,
+      get_result: getResult,
+    }
+    let thrown: unknown
+
+    try {
+      runSteppedRunnerToCompletion(runner, controller.signal, () => {
+        controller.abort()
+      })
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect((thrown as Error).name).toBe('AbortError')
+    expect(runSteps).not.toHaveBeenCalled()
+    expect(getResult).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/compute/worker/steppedRunner.ts
+++ b/web/src/compute/worker/steppedRunner.ts
@@ -1,0 +1,39 @@
+import type { ContinuationProgress } from '../ForkCoreClient'
+
+const DEFAULT_PROGRESS_UPDATES = 50
+
+export type SteppedRunner<TResult> = {
+  get_progress: () => ContinuationProgress
+  run_steps: (batchSize: number) => ContinuationProgress
+  get_result: () => TResult
+}
+
+function computeBatchSize(maxSteps: number): number {
+  if (!Number.isFinite(maxSteps) || maxSteps <= 0) return 1
+  return Math.max(1, Math.ceil(maxSteps / DEFAULT_PROGRESS_UPDATES))
+}
+
+function abortIfNeeded(signal: AbortSignal): void {
+  if (!signal.aborted) return
+  const error = new Error('cancelled')
+  error.name = 'AbortError'
+  throw error
+}
+
+export function runSteppedRunnerToCompletion<TResult>(
+  runner: SteppedRunner<TResult>,
+  signal: AbortSignal,
+  onProgress: (progress: ContinuationProgress) => void
+): TResult {
+  let progress = runner.get_progress()
+  onProgress(progress)
+
+  const batchSize = computeBatchSize(progress.max_steps)
+  while (!progress.done) {
+    abortIfNeeded(signal)
+    progress = runner.run_steps(batchSize)
+    onProgress(progress)
+  }
+
+  return runner.get_result()
+}


### PR DESCRIPTION
Centralizes repeated stepped-runner control flow in the web worker.

Changes:
- Adds a typed `runSteppedRunnerToCompletion` helper for batching, progress reporting, cancellation, and result retrieval.
- Replaces duplicated stepped-runner loops in `forkCoreWorker.ts`.
- Preserves specialized runner construction and homoclinic result post-processing.
- Adds focused tests covering batching, progress, completion, and cancellation.

Validation completed before merge:
- Web lint
- Focused stepped-runner tests
- Worker integration tests
- Full web unit suite
- Web/Rust-WASM build