### PR TITLE
chore: execute Rust runner lifecycle refactor

### DIFF
--- a/.github/scripts/refactor_runner_lifecycle.py
+++ b/.github/scripts/refactor_runner_lifecycle.py
@@ -1,0 +1,312 @@
+from pathlib import Path
+
+
+boundary_path = Path("crates/fork_wasm/src/continuation/runner_boundary.rs")
+boundary = boundary_path.read_text()
+
+old_import = """use fork_core::continuation::{
+    ContinuationBranch, ContinuationPoint, ContinuationProblem, ContinuationRunner,
+    ContinuationSettings,
+};
+"""
+new_import = """use fork_core::continuation::{
+    ContinuationBranch, ContinuationPoint, ContinuationProblem, ContinuationRunner,
+    ContinuationSettings, StepResult,
+};
+"""
+if boundary.count(old_import) != 1:
+    raise SystemExit("expected continuation import block")
+boundary = boundary.replace(old_import, new_import, 1)
+
+if boundary.count("use serde::Serialize;\n") != 1:
+    raise SystemExit("expected serde import")
+boundary = boundary.replace("use serde::Serialize;\n", "use serde::Serialize;\nuse std::fmt;\n", 1)
+
+start_marker = "pub(crate) struct OwnedContinuationRunner"
+end_marker = """impl<P: ContinuationProblem + 'static> Drop for OwnedContinuationRunner<P> {
+    fn drop(&mut self) {
+        let _ = self.runner.take();
+    }
+}
+"""
+start = boundary.find(start_marker)
+end_start = boundary.find(end_marker, start)
+if start < 0 or end_start < 0:
+    raise SystemExit("expected existing owned runner lifecycle block")
+end = end_start + len(end_marker)
+
+new_lifecycle = r'''#[derive(Debug)]
+pub(crate) enum RunnerHandleError {
+    NotInitialized,
+    Step(anyhow::Error),
+}
+
+impl fmt::Display for RunnerHandleError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotInitialized => formatter.write_str("Runner not initialized"),
+            Self::Step(error) => write!(formatter, "Continuation step failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for RunnerHandleError {}
+
+pub(crate) struct RunnerHandle<P: ContinuationProblem> {
+    runner: Option<ContinuationRunner<P>>,
+}
+
+impl<P: ContinuationProblem> RunnerHandle<P> {
+    pub(crate) fn new(runner: ContinuationRunner<P>) -> Self {
+        Self {
+            runner: Some(runner),
+        }
+    }
+
+    pub(crate) fn is_done(&self) -> bool {
+        self.runner.as_ref().map_or(true, |runner| runner.is_done())
+    }
+
+    pub(crate) fn run_steps(
+        &mut self,
+        batch_size: u32,
+    ) -> Result<StepResult, RunnerHandleError> {
+        self.runner_mut()?
+            .run_steps(batch_size as usize)
+            .map_err(RunnerHandleError::Step)
+    }
+
+    pub(crate) fn get_progress(&self) -> Result<StepResult, RunnerHandleError> {
+        Ok(self.runner_ref()?.step_result())
+    }
+
+    pub(crate) fn take_result(
+        &mut self,
+    ) -> Result<ContinuationBranch, RunnerHandleError> {
+        let runner = self
+            .runner
+            .take()
+            .ok_or(RunnerHandleError::NotInitialized)?;
+        Ok(runner.take_result())
+    }
+
+    pub(crate) fn runner_mut(
+        &mut self,
+    ) -> Result<&mut ContinuationRunner<P>, RunnerHandleError> {
+        self.runner
+            .as_mut()
+            .ok_or(RunnerHandleError::NotInitialized)
+    }
+
+    pub(crate) fn run_steps_js(&mut self, batch_size: u32) -> Result<JsValue, JsValue> {
+        let result = self.run_steps(batch_size).map_err(runner_error_to_js)?;
+        serialize_js(&result)
+    }
+
+    pub(crate) fn get_progress_js(&self) -> Result<JsValue, JsValue> {
+        let progress = self.get_progress().map_err(runner_error_to_js)?;
+        serialize_js(&progress)
+    }
+
+    fn runner_ref(&self) -> Result<&ContinuationRunner<P>, RunnerHandleError> {
+        self.runner
+            .as_ref()
+            .ok_or(RunnerHandleError::NotInitialized)
+    }
+
+    fn clear(&mut self) {
+        let _ = self.runner.take();
+    }
+}
+
+pub(crate) fn runner_error_to_js(error: RunnerHandleError) -> JsValue {
+    JsValue::from_str(&error.to_string())
+}
+
+pub(crate) struct OwnedContinuationRunner<P: ContinuationProblem + 'static> {
+    runner: RunnerHandle<P>,
+    #[allow(dead_code)]
+    system: Box<EquationSystem>,
+}
+
+impl<P: ContinuationProblem + 'static> OwnedContinuationRunner<P> {
+    pub(crate) fn new<F>(
+        system: EquationSystem,
+        build_problem: F,
+        initial_point: ContinuationPoint,
+        settings: ContinuationSettings,
+        forward: bool,
+        problem_label: &str,
+    ) -> Result<Self, JsValue>
+    where
+        F: FnOnce(&'static mut EquationSystem) -> anyhow::Result<P>,
+    {
+        let mut system = Box::new(system);
+        let problem = build_problem(static_system_ref(&mut system)).map_err(|err| {
+            JsValue::from_str(&format!("Failed to create {problem_label} problem: {err}"))
+        })?;
+        let runner = ContinuationRunner::new(problem, initial_point, settings, forward)
+            .map_err(|err| JsValue::from_str(&format!("Continuation init failed: {err}")))?;
+
+        Ok(Self {
+            runner: RunnerHandle::new(runner),
+            system,
+        })
+    }
+
+    pub(crate) fn is_done(&self) -> bool {
+        self.runner.is_done()
+    }
+
+    pub(crate) fn run_steps(&mut self, batch_size: u32) -> Result<JsValue, JsValue> {
+        self.runner.run_steps_js(batch_size)
+    }
+
+    pub(crate) fn get_progress(&self) -> Result<JsValue, JsValue> {
+        self.runner.get_progress_js()
+    }
+
+    pub(crate) fn take_result(&mut self) -> Result<ContinuationBranch, JsValue> {
+        self.runner.take_result().map_err(runner_error_to_js)
+    }
+
+    pub(crate) fn runner_mut(&mut self) -> Result<&mut ContinuationRunner<P>, JsValue> {
+        self.runner.runner_mut().map_err(runner_error_to_js)
+    }
+}
+
+impl<P: ContinuationProblem + 'static> Drop for OwnedContinuationRunner<P> {
+    fn drop(&mut self) {
+        self.runner.clear();
+    }
+}
+'''
+
+boundary = boundary[:start] + new_lifecycle + boundary[end:]
+boundary = boundary.replace(
+    "// ContinuationRunner that stores this borrow. The runner is dropped before\n",
+    "// RunnerHandle that stores this borrow. The runner is dropped before\n",
+    1,
+)
+boundary_path.write_text(boundary)
+
+
+eq_path = Path("crates/fork_wasm/src/continuation/eq_runner.rs")
+eq = eq_path.read_text()
+
+shared_import = "use super::shared::OwnedEquilibriumContinuationProblem;\n"
+if eq.count(shared_import) != 1:
+    raise SystemExit("expected equilibrium shared import")
+eq = eq.replace(
+    shared_import,
+    "use super::runner_boundary::{runner_error_to_js, serialize_js, RunnerHandle};\n"
+    + shared_import,
+    1,
+)
+
+eq = eq.replace(
+    "use serde_wasm_bindgen::{from_value, to_value};\n",
+    "use serde_wasm_bindgen::from_value;\n",
+    1,
+)
+
+old_field = "    runner: Option<ContinuationRunner<OwnedEquilibriumContinuationProblem>>,\n"
+new_field = "    runner: RunnerHandle<OwnedEquilibriumContinuationProblem>,\n"
+if eq.count(old_field) != 1:
+    raise SystemExit("expected equilibrium runner field")
+eq = eq.replace(old_field, new_field, 1)
+
+old_constructor = """        Ok(WasmEquilibriumRunner {
+            runner: Some(runner),
+            periodicity,
+        })
+"""
+new_constructor = """        Ok(WasmEquilibriumRunner {
+            runner: RunnerHandle::new(runner),
+            periodicity,
+        })
+"""
+if eq.count(old_constructor) != 1:
+    raise SystemExit("expected equilibrium runner constructor")
+eq = eq.replace(old_constructor, new_constructor, 1)
+
+old_methods = """    /// Check if the continuation is complete.
+    pub fn is_done(&self) -> bool {
+        self.runner.as_ref().map_or(true, |runner| runner.is_done())
+    }
+
+    /// Run a batch of continuation steps and return progress.
+    pub fn run_steps(&mut self, batch_size: u32) -> Result<JsValue, JsValue> {
+        let runner = self
+            .runner
+            .as_mut()
+            .ok_or_else(|| JsValue::from_str("Runner not initialized"))?;
+
+        let result = runner
+            .run_steps(batch_size as usize)
+            .map_err(|e| JsValue::from_str(&format!("Continuation step failed: {}", e)))?;
+
+        to_value(&result).map_err(|e| JsValue::from_str(&format!("Serialization error: {}", e)))
+    }
+
+    /// Get progress information.
+    pub fn get_progress(&self) -> Result<JsValue, JsValue> {
+        let runner = self
+            .runner
+            .as_ref()
+            .ok_or_else(|| JsValue::from_str("Runner not initialized"))?;
+
+        let result = runner.step_result();
+
+        to_value(&result).map_err(|e| JsValue::from_str(&format!("Serialization error: {}", e)))
+    }
+
+    /// Get the final branch result.
+    pub fn get_result(&mut self) -> Result<JsValue, JsValue> {
+        let runner = self
+            .runner
+            .take()
+            .ok_or_else(|| JsValue::from_str("Runner not initialized"))?;
+
+        let mut branch = runner.take_result();
+        wrap_equilibrium_branch(&mut branch, &self.periodicity);
+
+        to_value(&branch).map_err(|e| JsValue::from_str(&format!("Serialization error: {}", e)))
+    }
+"""
+new_methods = """    /// Check if the continuation is complete.
+    pub fn is_done(&self) -> bool {
+        self.runner.is_done()
+    }
+
+    /// Run a batch of continuation steps and return progress.
+    pub fn run_steps(&mut self, batch_size: u32) -> Result<JsValue, JsValue> {
+        self.runner.run_steps_js(batch_size)
+    }
+
+    /// Get progress information.
+    pub fn get_progress(&self) -> Result<JsValue, JsValue> {
+        self.runner.get_progress_js()
+    }
+
+    /// Get the final branch result.
+    pub fn get_result(&mut self) -> Result<JsValue, JsValue> {
+        let mut branch = self.runner.take_result().map_err(runner_error_to_js)?;
+        wrap_equilibrium_branch(&mut branch, &self.periodicity);
+        serialize_js(&branch)
+    }
+"""
+if eq.count(old_methods) != 1:
+    raise SystemExit("expected equilibrium lifecycle methods")
+eq = eq.replace(old_methods, new_methods, 1)
+
+test_import = "    use fork_core::continuation::ContinuationSettings;\n"
+if eq.count(test_import) != 1:
+    raise SystemExit("expected equilibrium test import")
+eq = eq.replace(
+    test_import,
+    test_import + "    use serde_wasm_bindgen::to_value;\n",
+    1,
+)
+
+eq_path.write_text(eq)

--- a/.github/workflows/runner-lifecycle-executor.yml
+++ b/.github/workflows/runner-lifecycle-executor.yml
@@ -47,6 +47,10 @@ jobs:
         working-directory: target
         run: python ../automation/.github/scripts/refactor_runner_lifecycle.py
 
+      - name: Format Rust
+        working-directory: target
+        run: cargo fmt --all
+
       - name: Verify refactor shape and formatting
         working-directory: target
         shell: bash

--- a/.github/workflows/runner-lifecycle-executor.yml
+++ b/.github/workflows/runner-lifecycle-executor.yml
@@ -1,0 +1,108 @@
+name: Temporary Rust runner lifecycle executor
+
+on:
+  pull_request:
+    branches:
+      - refactor/rust-runner-lifecycle
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refactor-test-commit:
+    if: github.repository == 'hinsley/Fork'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out automation source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: automation
+
+      - name: Check out feature branch
+        uses: actions/checkout@v4
+        with:
+          ref: refactor/rust-runner-lifecycle
+          fetch-depth: 0
+          path: target
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            target/cli/package-lock.json
+            target/web/package-lock.json
+
+      - name: Apply runner lifecycle refactor
+        working-directory: target
+        run: python ../automation/.github/scripts/refactor_runner_lifecycle.py
+
+      - name: Verify refactor shape and formatting
+        working-directory: target
+        shell: bash
+        run: |
+          git diff --check
+          grep -q 'pub(crate) struct RunnerHandle' crates/fork_wasm/src/continuation/runner_boundary.rs
+          grep -q 'runner: RunnerHandle<OwnedEquilibriumContinuationProblem>' crates/fork_wasm/src/continuation/eq_runner.rs
+          ! grep -q 'runner: Option<ContinuationRunner<OwnedEquilibriumContinuationProblem>>' crates/fork_wasm/src/continuation/eq_runner.rs
+          cargo fmt --all -- --check
+
+      - name: Run focused WASM crate tests
+        working-directory: target
+        run: cargo test -p fork_wasm
+
+      - name: Run Rust workspace tests
+        working-directory: target
+        run: cargo test --workspace
+
+      - name: Rebuild Node WASM bindings
+        working-directory: target/crates/fork_wasm
+        run: wasm-pack build --target nodejs
+
+      - name: Install and validate CLI
+        working-directory: target/cli
+        run: |
+          npm ci
+          npm run build
+          npm test
+
+      - name: Install and validate web
+        working-directory: target/web
+        run: |
+          npm ci
+          npm run build
+          npm run test:unit
+
+      - name: Commit tested implementation
+        working-directory: target
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            crates/fork_wasm/src/continuation/runner_boundary.rs \
+            crates/fork_wasm/src/continuation/eq_runner.rs
+          git diff --cached --check
+          git commit -m "refactor(wasm): share continuation runner lifecycle"
+          git push origin HEAD:refs/heads/refactor/rust-runner-lifecycle
+
+      - name: Close and remove temporary automation branch
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr close "$PR_NUMBER" \
+            --repo hinsley/Fork \
+            --comment "Automation completed: the tested runner-lifecycle implementation was committed to refactor/rust-runner-lifecycle." \
+            --delete-branch


### PR DESCRIPTION
Temporary automation PR into `refactor/rust-runner-lifecycle`. It applies the implementation after the failing test-only commit, runs Rust formatting and workspace tests, rebuilds Node WASM, validates the CLI smoke/unit suite, builds and tests the web app, commits the tested implementation to the feature branch, then closes itself.