### PR TITLE
chore: inspect generated wasm-pack declarations

### DIFF
--- a/.github/workflows/inspect-wasm-declarations.yml
+++ b/.github/workflows/inspect-wasm-declarations.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           wasm-pack build --target web --out-dir pkg-web
           wasm-pack build --target nodejs
-      - name: Upload generated package metadata
+      - name: Upload generated package metadata and source seams
         uses: actions/upload-artifact@v4
         with:
           name: wasm-pack-declarations
@@ -30,4 +30,13 @@ jobs:
             crates/fork_wasm/pkg-web/package.json
             crates/fork_wasm/pkg/fork_wasm.d.ts
             crates/fork_wasm/pkg/package.json
+            web/src/compute/worker/forkCoreWorker.ts
+            web/src/compute/worker/forkCoreWorker.test.ts
+            web/src/types/wasm.d.ts
+            web/vite.config.ts
+            web/tsconfig.app.json
+            web/package.json
+            cli/src/wasm.ts
+            cli/package.json
+            cli/tsconfig.json
           if-no-files-found: error

--- a/.github/workflows/inspect-wasm-declarations.yml
+++ b/.github/workflows/inspect-wasm-declarations.yml
@@ -1,0 +1,32 @@
+name: Inspect generated wasm declarations
+
+on:
+  push:
+    branches:
+      - automation/inspect-wasm-declarations
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: jetli/wasm-pack-action@v0.4.0
+      - name: Generate web and Node packages
+        working-directory: crates/fork_wasm
+        run: |
+          wasm-pack build --target web --out-dir pkg-web
+          wasm-pack build --target nodejs
+      - name: Upload generated package metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-pack-declarations
+          path: |
+            crates/fork_wasm/pkg-web/fork_wasm.d.ts
+            crates/fork_wasm/pkg-web/package.json
+            crates/fork_wasm/pkg/fork_wasm.d.ts
+            crates/fork_wasm/pkg/package.json
+          if-no-files-found: error

--- a/.github/workflows/inspect-wasm-declarations.yml
+++ b/.github/workflows/inspect-wasm-declarations.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - automation/inspect-wasm-declarations
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
Temporary inspection PR used only to generate and download the exact web and Node `wasm-pack` declaration files. It will be closed and the branch removed after inspection.