### PR TITLE
chore: execute generated wasm-pack declaration refactor

### DIFF
--- a/.github/scripts/refactor_generated_wasm_declarations.py
+++ b/.github/scripts/refactor_generated_wasm_declarations.py
@@ -1,0 +1,262 @@
+from pathlib import Path
+import json
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise RuntimeError(f"Expected exactly one {label}; found {count}")
+    return text.replace(old, new, 1)
+
+
+# Web: resolve @fork-wasm as the generated package, including its package.json/types entry.
+vite_path = Path("web/vite.config.ts")
+vite = vite_path.read_text()
+vite = replace_once(
+    vite,
+    """      '@fork-wasm': path.resolve(\n        __dirname,\n        '..',\n        'crates',\n        'fork_wasm',\n        'pkg-web',\n        'fork_wasm.js'\n      ),""",
+    """      '@fork-wasm': path.resolve(__dirname, '..', 'crates', 'fork_wasm', 'pkg-web'),""",
+    "web WASM alias",
+)
+vite_path.write_text(vite)
+
+web_tsconfig_path = Path("web/tsconfig.app.json")
+web_tsconfig = web_tsconfig_path.read_text()
+web_tsconfig = replace_once(
+    web_tsconfig,
+    '    "module": "ESNext",\n',
+    '    "module": "ESNext",\n    "baseUrl": ".",\n    "paths": {\n      "@fork-wasm": ["../crates/fork_wasm/pkg-web"]\n    },\n',
+    "web TypeScript WASM path",
+)
+web_tsconfig_path.write_text(web_tsconfig)
+
+ambient_path = Path("web/src/types/wasm.d.ts")
+if not ambient_path.exists():
+    raise RuntimeError("Expected the hand-maintained web WASM declaration shim")
+ambient_path.unlink()
+
+worker_path = Path("web/src/compute/worker/forkCoreWorker.ts")
+worker = worker_path.read_text()
+worker = replace_once(
+    worker,
+    "  ContinuationBranchDataWire,\n",
+    "",
+    "ContinuationBranchDataWire import",
+)
+manual_type_start = worker.index("type WasmModule = {")
+manual_type_end = worker.index("\n\nconst pendingControllers", manual_type_start)
+module_types = """type WasmModule = typeof import('@fork-wasm')
+type GeneratedWasmSystem = InstanceType<WasmModule['WasmSystem']>
+type WasmSystem = Omit<
+  GeneratedWasmSystem,
+  | 'compute_event_series_from_orbit'
+  | 'compute_event_series_from_samples'
+  | 'compute_isocline'
+> & {
+  compute_event_series_from_orbit?: GeneratedWasmSystem['compute_event_series_from_orbit']
+  computeEventSeriesFromOrbit?: GeneratedWasmSystem['compute_event_series_from_orbit']
+  compute_event_series_from_samples?: GeneratedWasmSystem['compute_event_series_from_samples']
+  computeEventSeriesFromSamples?: GeneratedWasmSystem['compute_event_series_from_samples']
+  compute_isocline?: GeneratedWasmSystem['compute_isocline']
+  computeIsocline?: GeneratedWasmSystem['compute_isocline']
+}"""
+worker = worker[:manual_type_start] + module_types + worker[manual_type_end:]
+worker = replace_once(
+    worker,
+    """    wasmPromise = import('@fork-wasm').then(async (mod) => {
+      if (typeof mod.default === 'function') {
+        await mod.default()
+      }
+      return mod as WasmModule
+    })""",
+    """    wasmPromise = import('@fork-wasm').then(async (module) => {
+      await module.default()
+      return module
+    })""",
+    "web WASM loader",
+)
+worker = replace_once(
+    worker,
+    "function createWasmSystem(wasm: WasmModule, system: SystemConfig) {",
+    "function createWasmSystem(wasm: WasmModule, system: SystemConfig): WasmSystem {",
+    "createWasmSystem signature",
+)
+worker = replace_once(
+    worker,
+    """    system.type
+  )
+  instance.set_periods?.(new Float64Array(periodicPeriodsForConfig(system)))""",
+    """    system.type
+  ) as WasmSystem
+  instance.set_periods(new Float64Array(periodicPeriodsForConfig(system)))""",
+    "generated WasmSystem construction",
+)
+worker = replace_once(
+    worker,
+    """  const axisMins = request.axes.map((axis) => axis.min)
+  const axisMaxs = request.axes.map((axis) => axis.max)
+  const axisSamples = request.axes.map((axis) => axis.samples)""",
+    """  const axisIndexValues = Uint32Array.from(axisIndices)
+  const axisMins = Float64Array.from(request.axes.map((axis) => axis.min))
+  const axisMaxs = Float64Array.from(request.axes.map((axis) => axis.max))
+  const axisSamples = Uint32Array.from(request.axes.map((axis) => axis.samples))
+  const frozenState = Float64Array.from(request.frozenState)""",
+    "isocline typed-array preparation",
+)
+worker = replace_once(worker, "    axisIndices,\n", "    axisIndexValues,\n", "isocline axis arguments")
+worker = replace_once(worker, "    request.frozenState,\n", "    frozenState,\n", "isocline frozen state")
+worker = replace_once(
+    worker,
+    """  return system.solve_equilibrium(
+    request.initialGuess,""",
+    """  return system.solve_equilibrium(
+    new Float64Array(request.initialGuess),""",
+    "equilibrium initial guess conversion",
+)
+worker = replace_once(
+    worker,
+    """  let seed = system.init_map_cycle_from_pd(
+    request.pdState,""",
+    """  let seed = system.init_map_cycle_from_pd(
+    new Float64Array(request.pdState),""",
+    "map-cycle PD seed conversion",
+)
+worker = replace_once(
+    worker,
+    """    const solution = system.solve_equilibrium(
+      seed,""",
+    """    const solution = system.solve_equilibrium(
+      new Float64Array(seed),""",
+    "map-cycle equilibrium seed conversion",
+)
+if "type WasmModule = {" in worker:
+    raise RuntimeError("Hand-maintained WasmModule declaration remains")
+worker_path.write_text(worker)
+
+# CLI: guarantee the generated Node package exists before TypeScript compilation.
+cli_package_path = Path("cli/package.json")
+cli_package = json.loads(cli_package_path.read_text())
+scripts = cli_package["scripts"]
+new_scripts = {}
+for key, value in scripts.items():
+    if key == "start":
+        new_scripts["prestart"] = "npm run wasm:node"
+    if key == "build":
+        new_scripts["prebuild"] = "npm run wasm:node"
+    new_scripts[key] = value
+cli_package["scripts"] = new_scripts
+cli_package_path.write_text(json.dumps(cli_package, indent=2) + "\n")
+
+cli_wasm_path = Path("cli/src/wasm.ts")
+cli = cli_wasm_path.read_text()
+cli = replace_once(
+    cli,
+    """// We use require to load the WASM bindings generated by wasm-pack target nodejs
+let wasmModule: any;""",
+    """export type ForkWasmModule = typeof import("../../crates/fork_wasm/pkg/fork_wasm");
+export type GeneratedWasmSystem = InstanceType<ForkWasmModule["WasmSystem"]>;
+type WasmSystem = GeneratedWasmSystem & {
+    continue_limit_cycle_from_hopf?: (
+        hopfState: Float64Array,
+        hopfParam: number,
+        parameterName: string,
+        methodRequest: unknown,
+        amplitude: number,
+        settings: unknown,
+        forward: boolean
+    ) => unknown;
+    extend_limit_cycle_branch?: (
+        branchData: unknown,
+        parameterName: string,
+        meta: LimitCycleMeta,
+        settings: unknown,
+        forward: boolean
+    ) => unknown;
+};
+
+// We use require to load the WASM bindings generated by wasm-pack target nodejs
+let wasmModule: ForkWasmModule | undefined;""",
+    "CLI generated module type",
+)
+cli = replace_once(
+    cli,
+    '    wasmModule = require("../../crates/fork_wasm/pkg/fork_wasm.js");',
+    '    wasmModule = require("../../crates/fork_wasm/pkg/fork_wasm.js") as ForkWasmModule;',
+    "typed Node WASM require",
+)
+cli = replace_once(cli, "    instance: any;", "    instance: WasmSystem;", "WasmBridge instance type")
+cli = replace_once(
+    cli,
+    """            systemType
+        );
+        this.instance.set_periods?.(new Float64Array(periodicPeriodsForConfig(this.config)));""",
+    """            systemType
+        ) as WasmSystem;
+        this.instance.set_periods(new Float64Array(periodicPeriodsForConfig(this.config)));""",
+    "typed WasmSystem construction",
+)
+cli = cli.replace("(wasmModule as any).", "wasmModule.")
+cli = replace_once(
+    cli,
+    """        return this.instance.continue_limit_cycle_from_hopf(
+            new Float64Array(hopfState),""",
+    """        const continueFromHopf = this.instance.continue_limit_cycle_from_hopf;
+        if (typeof continueFromHopf !== "function") {
+            throw new Error(
+                "Legacy limit-cycle continuation is unavailable in this WASM build."
+            );
+        }
+        return continueFromHopf(
+            new Float64Array(hopfState),""",
+    "legacy limit-cycle continuation guard",
+)
+cli = replace_once(
+    cli,
+    """        return this.instance.extend_limit_cycle_branch(
+            branchData,""",
+    """        const extendBranch = this.instance.extend_limit_cycle_branch;
+        if (typeof extendBranch !== "function") {
+            throw new Error(
+                "Legacy limit-cycle branch extension is unavailable in this WASM build."
+            );
+        }
+        return extendBranch(
+            branchData,""",
+    "legacy limit-cycle extension guard",
+)
+
+fold_start = cli.index("    continueFoldCurve(")
+fold_end = cli.index("\n    }", fold_start) + len("\n    }")
+fold_block = cli[fold_start:fold_end]
+fold_block = replace_once(
+    fold_block,
+    """            param2Name,
+            param2Value,
+            settings,""",
+    """            param2Name,
+            param2Value,
+            1,
+            settings,""",
+    "direct fold map-iteration argument",
+)
+cli = cli[:fold_start] + fold_block + cli[fold_end:]
+
+hopf_start = cli.index("    continueHopfCurve(")
+hopf_end = cli.index("\n    }", hopf_start) + len("\n    }")
+hopf_block = cli[hopf_start:hopf_end]
+hopf_block = replace_once(
+    hopf_block,
+    """            param2Name,
+            param2Value,
+            settings,""",
+    """            param2Name,
+            param2Value,
+            1,
+            settings,""",
+    "direct Hopf map-iteration argument",
+)
+cli = cli[:hopf_start] + hopf_block + cli[hopf_end:]
+
+if "let wasmModule: any" in cli or "instance: any" in cli or "(wasmModule as any)" in cli:
+    raise RuntimeError("Broad CLI WASM any typing remains")
+cli_wasm_path.write_text(cli)

--- a/.github/workflows/refactor-generated-wasm-declarations.yml
+++ b/.github/workflows/refactor-generated-wasm-declarations.yml
@@ -1,0 +1,122 @@
+name: Temporary generated WASM declaration executor
+
+on:
+  pull_request:
+    branches:
+      - refactor/generated-wasm-declarations
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refactor-test-commit:
+    if: github.repository == 'hinsley/Fork'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out automation source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: automation
+
+      - name: Check out feature branch
+        uses: actions/checkout@v4
+        with:
+          ref: refactor/generated-wasm-declarations
+          fetch-depth: 0
+          path: target
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            target/cli/package-lock.json
+            target/web/package-lock.json
+
+      - name: Apply generated-declaration refactor
+        working-directory: target
+        run: python ../automation/.github/scripts/refactor_generated_wasm_declarations.py
+
+      - name: Verify refactor shape
+        working-directory: target
+        shell: bash
+        run: |
+          git diff --check
+          test ! -e web/src/types/wasm.d.ts
+          grep -Fq "type WasmModule = typeof import('@fork-wasm')" web/src/compute/worker/forkCoreWorker.ts
+          ! grep -Fq 'type WasmModule = {' web/src/compute/worker/forkCoreWorker.ts
+          grep -Fq "'@fork-wasm': path.resolve(__dirname, '..', 'crates', 'fork_wasm', 'pkg-web')" web/vite.config.ts
+          grep -Fq '"@fork-wasm": ["../crates/fork_wasm/pkg-web"]' web/tsconfig.app.json
+          grep -Fq 'export type ForkWasmModule = typeof import' cli/src/wasm.ts
+          ! grep -Fq 'let wasmModule: any' cli/src/wasm.ts
+          ! grep -Fq 'instance: any' cli/src/wasm.ts
+          grep -Fq '"prebuild": "npm run wasm:node"' cli/package.json
+          grep -Fq '"prestart": "npm run wasm:node"' cli/package.json
+
+      - name: Run Rust workspace tests
+        working-directory: target
+        run: cargo test --workspace
+
+      - name: Validate clean-checkout CLI build and tests
+        working-directory: target
+        shell: bash
+        run: |
+          rm -rf crates/fork_wasm/pkg
+          cd cli
+          npm ci
+          npm run build
+          test -f ../crates/fork_wasm/pkg/fork_wasm.d.ts
+          npm test
+
+      - name: Validate clean-checkout web build and tests
+        working-directory: target
+        shell: bash
+        run: |
+          rm -rf crates/fork_wasm/pkg-web
+          cd web
+          npm ci
+          npm run lint
+          npm run build
+          test -f ../crates/fork_wasm/pkg-web/fork_wasm.d.ts
+          npx playwright install --with-deps
+          npm test
+
+      - name: Commit tested implementation
+        working-directory: target
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A -- \
+            web/vite.config.ts \
+            web/tsconfig.app.json \
+            web/src/types/wasm.d.ts \
+            web/src/compute/worker/forkCoreWorker.ts \
+            cli/package.json \
+            cli/src/wasm.ts
+          git diff --cached --check
+          git commit -m "refactor(wasm): consume generated wasm-pack declarations"
+          git push origin HEAD:refs/heads/refactor/generated-wasm-declarations
+
+      - name: Close and remove temporary branches
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr close "$PR_NUMBER" \
+            --repo hinsley/Fork \
+            --comment "Automation completed: the tested generated-declaration implementation was committed to refactor/generated-wasm-declarations." \
+            --delete-branch
+          gh pr close 30 --repo hinsley/Fork --comment "Inspection complete; generated declaration artifacts were consumed by the feature implementation." || true
+          gh api -X DELETE repos/hinsley/Fork/git/refs/heads/automation/inspect-wasm-declarations || true

--- a/.github/workflows/refactor-generated-wasm-declarations.yml
+++ b/.github/workflows/refactor-generated-wasm-declarations.yml
@@ -54,19 +54,32 @@ jobs:
           python ../automation/.github/scripts/refactor_generated_wasm_declarations.py
           python <<'PY'
           from pathlib import Path
-          path = Path('cli/src/wasm.ts')
-          source = path.read_text()
-          source = source.replace(
+
+          cli_path = Path('cli/src/wasm.ts')
+          cli_source = cli_path.read_text()
+          cli_source = cli_source.replace(
               '        return continueFromHopf(\n            new Float64Array(hopfState),',
               '        return continueFromHopf.call(\n            this.instance,\n            new Float64Array(hopfState),',
               1,
           )
-          source = source.replace(
+          cli_source = cli_source.replace(
               '        return extendBranch(\n            branchData,',
               '        return extendBranch.call(\n            this.instance,\n            branchData,',
               1,
           )
-          path.write_text(source)
+          cli_path.write_text(cli_source)
+
+          mock_path = Path('web/src/compute/worker/forkCoreWorker.test.ts')
+          mock_source = mock_path.read_text()
+          anchor = '      set_state(state: Float64Array) {\n'
+          if mock_source.count(anchor) != 1:
+              raise RuntimeError('Expected one MockWasmSystem set_state method')
+          mock_source = mock_source.replace(
+              anchor,
+              '      set_periods() {}\n' + anchor,
+              1,
+          )
+          mock_path.write_text(mock_source)
           PY
 
       - name: Verify refactor shape
@@ -84,6 +97,7 @@ jobs:
           ! grep -Fq 'instance: any' cli/src/wasm.ts
           grep -Fq 'return continueFromHopf.call(' cli/src/wasm.ts
           grep -Fq 'return extendBranch.call(' cli/src/wasm.ts
+          grep -Fq '      set_periods() {}' web/src/compute/worker/forkCoreWorker.test.ts
           grep -Fq '"prebuild": "npm run wasm:node"' cli/package.json
           grep -Fq '"prestart": "npm run wasm:node"' cli/package.json
 
@@ -162,6 +176,7 @@ jobs:
             web/tsconfig.app.json \
             web/src/types/wasm.d.ts \
             web/src/compute/worker/forkCoreWorker.ts \
+            web/src/compute/worker/forkCoreWorker.test.ts \
             cli/package.json \
             cli/src/wasm.ts
           git diff --cached --check

--- a/.github/workflows/refactor-generated-wasm-declarations.yml
+++ b/.github/workflows/refactor-generated-wasm-declarations.yml
@@ -102,18 +102,36 @@ jobs:
           test -f ../crates/fork_wasm/pkg/fork_wasm.d.ts
           npm test
 
-      - name: Validate clean-checkout web build and tests
+      - name: Install web dependencies from a clean generated-package state
         working-directory: target
         shell: bash
         run: |
           rm -rf crates/fork_wasm/pkg-web
           cd web
           npm ci
-          npm run lint
+
+      - name: Lint web
+        working-directory: target/web
+        run: npm run lint
+
+      - name: Build web and generated declarations
+        working-directory: target/web
+        shell: bash
+        run: |
           npm run build
           test -f ../crates/fork_wasm/pkg-web/fork_wasm.d.ts
-          npx playwright install --with-deps
-          npm test
+
+      - name: Run web unit tests
+        working-directory: target/web
+        run: npm run test:unit
+
+      - name: Install Playwright browsers
+        working-directory: target/web
+        run: npx playwright install --with-deps
+
+      - name: Run web end-to-end tests
+        working-directory: target/web
+        run: npm run test:e2e
 
       - name: Commit tested implementation
         working-directory: target

--- a/.github/workflows/refactor-generated-wasm-declarations.yml
+++ b/.github/workflows/refactor-generated-wasm-declarations.yml
@@ -6,6 +6,10 @@ on:
       - refactor/generated-wasm-declarations
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: generated-wasm-declarations-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/refactor-generated-wasm-declarations.yml
+++ b/.github/workflows/refactor-generated-wasm-declarations.yml
@@ -49,7 +49,25 @@ jobs:
 
       - name: Apply generated-declaration refactor
         working-directory: target
-        run: python ../automation/.github/scripts/refactor_generated_wasm_declarations.py
+        shell: bash
+        run: |
+          python ../automation/.github/scripts/refactor_generated_wasm_declarations.py
+          python <<'PY'
+          from pathlib import Path
+          path = Path('cli/src/wasm.ts')
+          source = path.read_text()
+          source = source.replace(
+              '        return continueFromHopf(\n            new Float64Array(hopfState),',
+              '        return continueFromHopf.call(\n            this.instance,\n            new Float64Array(hopfState),',
+              1,
+          )
+          source = source.replace(
+              '        return extendBranch(\n            branchData,',
+              '        return extendBranch.call(\n            this.instance,\n            branchData,',
+              1,
+          )
+          path.write_text(source)
+          PY
 
       - name: Verify refactor shape
         working-directory: target
@@ -64,6 +82,8 @@ jobs:
           grep -Fq 'export type ForkWasmModule = typeof import' cli/src/wasm.ts
           ! grep -Fq 'let wasmModule: any' cli/src/wasm.ts
           ! grep -Fq 'instance: any' cli/src/wasm.ts
+          grep -Fq 'return continueFromHopf.call(' cli/src/wasm.ts
+          grep -Fq 'return extendBranch.call(' cli/src/wasm.ts
           grep -Fq '"prebuild": "npm run wasm:node"' cli/package.json
           grep -Fq '"prestart": "npm run wasm:node"' cli/package.json
 

--- a/.github/workflows/refactor-generated-wasm-declarations.yml
+++ b/.github/workflows/refactor-generated-wasm-declarations.yml
@@ -87,21 +87,6 @@ jobs:
           grep -Fq '"prebuild": "npm run wasm:node"' cli/package.json
           grep -Fq '"prestart": "npm run wasm:node"' cli/package.json
 
-      - name: Run Rust workspace tests
-        working-directory: target
-        run: cargo test --workspace
-
-      - name: Validate clean-checkout CLI build and tests
-        working-directory: target
-        shell: bash
-        run: |
-          rm -rf crates/fork_wasm/pkg
-          cd cli
-          npm ci
-          npm run build
-          test -f ../crates/fork_wasm/pkg/fork_wasm.d.ts
-          npm test
-
       - name: Install web dependencies from a clean generated-package state
         working-directory: target
         shell: bash
@@ -123,7 +108,40 @@ jobs:
 
       - name: Run web unit tests
         working-directory: target/web
-        run: npm run test:unit
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set +e
+          npm run test:unit > /tmp/web-unit.log 2>&1
+          status=$?
+          cat /tmp/web-unit.log
+          if [ "$status" -ne 0 ]; then
+            {
+              echo 'Web unit-test diagnostics:'
+              echo '```text'
+              tail -n 220 /tmp/web-unit.log
+              echo '```'
+            } > /tmp/web-unit-comment.md
+            gh pr comment "$PR_NUMBER" --repo hinsley/Fork --body-file /tmp/web-unit-comment.md
+            exit "$status"
+          fi
+
+      - name: Run Rust workspace tests
+        working-directory: target
+        run: cargo test --workspace
+
+      - name: Validate clean-checkout CLI build and tests
+        working-directory: target
+        shell: bash
+        run: |
+          rm -rf crates/fork_wasm/pkg
+          cd cli
+          npm ci
+          npm run build
+          test -f ../crates/fork_wasm/pkg/fork_wasm.d.ts
+          npm test
 
       - name: Install Playwright browsers
         working-directory: target/web


### PR DESCRIPTION
Temporary automation PR into `refactor/generated-wasm-declarations`. It applies the implementation after the failing compile-time contract tests, validates clean-checkout web and CLI package generation, runs Rust, CLI, web, and end-to-end tests, commits the tested implementation to the feature branch, then closes itself.